### PR TITLE
Increase tolerance for slow block creation in tests

### DIFF
--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -72,7 +72,7 @@ describe("CosmWasmClient", () => {
 
       const height1 = await client.getHeight();
       expect(height1).toBeGreaterThan(0);
-      await sleep(blockTime * 1.3); // tolerate chain being 30% slower than expected
+      await sleep(blockTime * 1.4); // tolerate chain being 40% slower than expected
       const height2 = await client.getHeight();
       expect(height2).toBeGreaterThanOrEqual(height1 + 1);
       expect(height2).toBeLessThanOrEqual(height1 + 2);

--- a/packages/sdk38/src/cosmosclient.spec.ts
+++ b/packages/sdk38/src/cosmosclient.spec.ts
@@ -60,7 +60,7 @@ describe("CosmosClient", () => {
 
       const height1 = await client.getHeight();
       expect(height1).toBeGreaterThan(0);
-      await sleep(blockTime * 1.3); // tolerate chain being 30% slower than expected
+      await sleep(blockTime * 1.4); // tolerate chain being 40% slower than expected
       const height2 = await client.getHeight();
       expect(height2).toBeGreaterThanOrEqual(height1 + 1);
       expect(height2).toBeLessThanOrEqual(height1 + 2);


### PR DESCRIPTION
The tests "gets height via last block" fail from time to time because the same height is returned after a 1300ms delay, e.g. [here](https://app.circleci.com/pipelines/github/CosmWasm/cosmjs/621/workflows/d5b70364-2dcf-4ba3-8ece-2a1a66a6764d/jobs/1918/steps). Let's try to harden that.

