### PR TITLE
Stabilize unsuccessful tx search

### DIFF
--- a/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { Coin, CosmosSdkTx, isMsgSend, makeSignBytes, MsgSend, Secp256k1Pen } from "@cosmjs/sdk38";
+import { Coin, coins, CosmosSdkTx, isMsgSend, makeSignBytes, MsgSend, Secp256k1Pen } from "@cosmjs/sdk38";
 import { assert, sleep } from "@cosmjs/utils";
 
 import { CosmWasmClient, isPostTxFailure } from "./cosmwasmclient";
@@ -47,11 +47,8 @@ describe("CosmWasmClient.searchTx", () => {
 
       {
         const recipient = makeRandomAddress();
-        const transferAmount: Coin = {
-          denom: "ucosm",
-          amount: "1234567",
-        };
-        const result = await client.sendTokens(recipient, [transferAmount]);
+        const transferAmount = coins(1234567, "ucosm");
+        const result = await client.sendTokens(recipient, transferAmount);
         await sleep(75); // wait until tx is indexed
         const txDetails = await new RestClient(wasmd.endpoint).txById(result.transactionHash);
         sendSuccessful = {
@@ -84,12 +81,7 @@ describe("CosmWasmClient.searchTx", () => {
       {
         const memo = "Sending more than I can afford";
         const recipient = makeRandomAddress();
-        const transferAmount = [
-          {
-            denom: "ucosm",
-            amount: "123456700000000",
-          },
-        ];
+        const transferAmount = coins(123456700000000, "ucosm");
         const sendMsg: MsgSend = {
           type: "cosmos-sdk/MsgSend",
           value: {
@@ -101,12 +93,7 @@ describe("CosmWasmClient.searchTx", () => {
           },
         };
         const fee = {
-          amount: [
-            {
-              denom: "ucosm",
-              amount: "2000",
-            },
-          ],
+          amount: coins(2000, "ucosm"),
           gas: "80000", // 80k
         };
         const { accountNumber, sequence } = await client.getNonce();

--- a/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
@@ -16,29 +16,27 @@ import {
   wasmdEnabled,
 } from "./testutils.spec";
 
-type TestSendTx =
-  | {
-      readonly sender: string;
-      readonly recipient: string;
-      readonly hash: string;
-      readonly height: number;
-      readonly tx: CosmosSdkTx;
-    }
-  | undefined;
+interface TestTxSend {
+  readonly sender: string;
+  readonly recipient: string;
+  readonly hash: string;
+  readonly height: number;
+  readonly tx: CosmosSdkTx;
+}
+
+interface TestTxExecute {
+  readonly sender: string;
+  readonly contract: string;
+  readonly hash: string;
+  readonly height: number;
+  readonly tx: CosmosSdkTx;
+}
 
 describe("CosmWasmClient.searchTx", () => {
-  let sendSuccessful: TestSendTx;
-  let sendSelfSuccessful: TestSendTx;
-  let sendUnsuccessful: TestSendTx;
-  let postedExecute:
-    | {
-        readonly sender: string;
-        readonly contract: string;
-        readonly hash: string;
-        readonly height: number;
-        readonly tx: CosmosSdkTx;
-      }
-    | undefined;
+  let sendSuccessful: TestTxSend | undefined;
+  let sendSelfSuccessful: TestTxSend | undefined;
+  let sendUnsuccessful: TestTxSend | undefined;
+  let execute: TestTxExecute | undefined;
 
   beforeAll(async () => {
     if (wasmdEnabled()) {
@@ -148,7 +146,7 @@ describe("CosmWasmClient.searchTx", () => {
         const result = await client.execute(hashInstance, msg);
         await sleep(75); // wait until tx is indexed
         const txDetails = await new RestClient(wasmd.endpoint).txById(result.transactionHash);
-        postedExecute = {
+        execute = {
           sender: alice.address0,
           contract: hashInstance,
           hash: result.transactionHash,
@@ -413,10 +411,10 @@ describe("CosmWasmClient.searchTx", () => {
 
     it("can search by message.contract_address", async () => {
       pendingWithoutWasmd();
-      assert(postedExecute, "value must be set in beforeAll()");
+      assert(execute, "value must be set in beforeAll()");
       const client = new CosmWasmClient(wasmd.endpoint);
       const results = await client.searchTx({
-        tags: [{ key: "message.contract_address", value: postedExecute.contract }],
+        tags: [{ key: "message.contract_address", value: execute.contract }],
       });
       expect(results.length).toBeGreaterThanOrEqual(1);
 
@@ -446,20 +444,20 @@ describe("CosmWasmClient.searchTx", () => {
       // Check details of most recent result
       expect(results[results.length - 1]).toEqual(
         jasmine.objectContaining({
-          height: postedExecute.height,
-          hash: postedExecute.hash,
-          tx: postedExecute.tx,
+          height: execute.height,
+          hash: execute.hash,
+          tx: execute.tx,
         }),
       );
     });
 
     it("can search by message.contract_address + message.action", async () => {
       pendingWithoutWasmd();
-      assert(postedExecute, "value must be set in beforeAll()");
+      assert(execute, "value must be set in beforeAll()");
       const client = new CosmWasmClient(wasmd.endpoint);
       const results = await client.searchTx({
         tags: [
-          { key: "message.contract_address", value: postedExecute.contract },
+          { key: "message.contract_address", value: execute.contract },
           { key: "message.action", value: "execute" },
         ],
       });
@@ -469,15 +467,15 @@ describe("CosmWasmClient.searchTx", () => {
       for (const result of results) {
         const msg = fromOneElementArray(result.tx.value.msg);
         assert(isMsgExecuteContract(msg), `${result.hash} (at ${result.height}) not an execute msg`);
-        expect(msg.value.contract).toEqual(postedExecute.contract);
+        expect(msg.value.contract).toEqual(execute.contract);
       }
 
       // Check details of most recent result
       expect(results[results.length - 1]).toEqual(
         jasmine.objectContaining({
-          height: postedExecute.height,
-          hash: postedExecute.hash,
-          tx: postedExecute.tx,
+          height: execute.height,
+          hash: execute.hash,
+          tx: execute.tx,
         }),
       );
     });

--- a/packages/sdk38/src/cosmosclient.searchtx.spec.ts
+++ b/packages/sdk38/src/cosmosclient.searchtx.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { assert, sleep } from "@cosmjs/utils";
 
-import { Coin } from "./coins";
+import { coins } from "./coins";
 import { CosmosClient, isPostTxFailure } from "./cosmosclient";
 import { makeSignBytes } from "./encoding";
 import { Secp256k1Pen } from "./pen";
@@ -39,12 +39,7 @@ describe("CosmosClient.searchTx", () => {
       {
         const memo = "Sending more than I can afford";
         const recipient = makeRandomAddress();
-        const transferAmount = [
-          {
-            denom: "ucosm",
-            amount: "123456700000000",
-          },
-        ];
+        const transferAmount = coins(123456700000000, "ucosm");
         const sendMsg: MsgSend = {
           type: "cosmos-sdk/MsgSend",
           value: {
@@ -56,12 +51,7 @@ describe("CosmosClient.searchTx", () => {
           },
         };
         const fee = {
-          amount: [
-            {
-              denom: "ucosm",
-              amount: "2000",
-            },
-          ],
+          amount: coins(2000, "ucosm"),
           gas: "80000", // 80k
         };
         const { accountNumber, sequence } = await client.getNonce();
@@ -92,11 +82,8 @@ describe("CosmosClient.searchTx", () => {
 
       {
         const recipient = makeRandomAddress();
-        const transferAmount: Coin = {
-          denom: "ucosm",
-          amount: "1234567",
-        };
-        const result = await client.sendTokens(recipient, [transferAmount]);
+        const transferAmount = coins(1234567, "ucosm");
+        const result = await client.sendTokens(recipient, transferAmount);
         await sleep(75); // wait until tx is indexed
         const txDetails = await new RestClient(wasmd.endpoint).txById(result.transactionHash);
         sendSuccessful = {

--- a/packages/sdk38/src/cosmosclient.searchtx.spec.ts
+++ b/packages/sdk38/src/cosmosclient.searchtx.spec.ts
@@ -26,8 +26,8 @@ interface TestTxSend {
 }
 
 describe("CosmosClient.searchTx", () => {
-  let sendSuccessful: TestTxSend | undefined;
   let sendUnsuccessful: TestTxSend | undefined;
+  let sendSuccessful: TestTxSend | undefined;
 
   beforeAll(async () => {
     if (wasmdEnabled()) {
@@ -35,24 +35,6 @@ describe("CosmosClient.searchTx", () => {
       const client = new SigningCosmosClient(wasmd.endpoint, faucet.address, (signBytes) =>
         pen.sign(signBytes),
       );
-
-      {
-        const recipient = makeRandomAddress();
-        const transferAmount: Coin = {
-          denom: "ucosm",
-          amount: "1234567",
-        };
-        const result = await client.sendTokens(recipient, [transferAmount]);
-        await sleep(75); // wait until tx is indexed
-        const txDetails = await new RestClient(wasmd.endpoint).txById(result.transactionHash);
-        sendSuccessful = {
-          sender: faucet.address,
-          recipient: recipient,
-          hash: result.transactionHash,
-          height: Number.parseInt(txDetails.height, 10),
-          tx: txDetails.tx,
-        };
-      }
 
       {
         const memo = "Sending more than I can afford";
@@ -106,6 +88,24 @@ describe("CosmosClient.searchTx", () => {
             tx: tx,
           };
         }
+      }
+
+      {
+        const recipient = makeRandomAddress();
+        const transferAmount: Coin = {
+          denom: "ucosm",
+          amount: "1234567",
+        };
+        const result = await client.sendTokens(recipient, [transferAmount]);
+        await sleep(75); // wait until tx is indexed
+        const txDetails = await new RestClient(wasmd.endpoint).txById(result.transactionHash);
+        sendSuccessful = {
+          sender: faucet.address,
+          recipient: recipient,
+          hash: result.transactionHash,
+          height: Number.parseInt(txDetails.height, 10),
+          tx: txDetails.tx,
+        };
       }
     }
   });

--- a/packages/sdk38/src/cosmosclient.searchtx.spec.ts
+++ b/packages/sdk38/src/cosmosclient.searchtx.spec.ts
@@ -17,25 +17,17 @@ import {
 } from "./testutils.spec";
 import { CosmosSdkTx, isMsgSend, MsgSend } from "./types";
 
+interface TestTxSend {
+  readonly sender: string;
+  readonly recipient: string;
+  readonly hash: string;
+  readonly height: number;
+  readonly tx: CosmosSdkTx;
+}
+
 describe("CosmosClient.searchTx", () => {
-  let sendSuccessful:
-    | {
-        readonly sender: string;
-        readonly recipient: string;
-        readonly hash: string;
-        readonly height: number;
-        readonly tx: CosmosSdkTx;
-      }
-    | undefined;
-  let sendUnsuccessful:
-    | {
-        readonly sender: string;
-        readonly recipient: string;
-        readonly hash: string;
-        readonly height: number;
-        readonly tx: CosmosSdkTx;
-      }
-    | undefined;
+  let sendSuccessful: TestTxSend | undefined;
+  let sendUnsuccessful: TestTxSend | undefined;
 
   beforeAll(async () => {
     if (wasmdEnabled()) {


### PR DESCRIPTION
In https://app.circleci.com/pipelines/github/CosmWasm/cosmjs/639/workflows/d43ce96b-a51f-4131-810c-8ebcb0eebed0/jobs/1991/steps the test fails sometime because there is not enough time between block creation and indexing the unsuccessful transaction. There is no sleep statement for `sendUnsuccessful` and the test before the failing one is very fast:

```
@cosmjs/sdk38:   2 CosmosClient.searchTx
@cosmjs/sdk38:     2.1 with SearchByIdQuery
@cosmjs/sdk38:       ✓ can search successful tx by ID (0.012 sec) 
@cosmjs/sdk38:       ✗ can search unsuccessful tx by ID (0.027 sec)
@cosmjs/sdk38:         - Expected 0 to equal 1.
@cosmjs/sdk38:         - Expected undefined to equal <jasmine.objectContaining(Object(…)>.
@cosmjs/sdk38:       ✓ can search by ID (non existent) (0.003 sec)
@cosmjs/sdk38:       ✓ can search by ID and filter by minHeight (0.028 sec)
```

In order to avoid this issue, the unsuccessful tx is not posted first, allowing us to utilize the sleep in

```ts
        const recipient = makeRandomAddress();
        const transferAmount = coins(1234567, "ucosm");
        const result = await client.sendTokens(recipient, transferAmount);
        await sleep(75); // wait until tx is indexed
        const txDetails = await new RestClient(wasmd.endpoint).txById(result.transactionHash);
        sendSuccessful = {
          sender: faucet.address,
          recipient: recipient,
          hash: result.transactionHash,
          height: Number.parseInt(txDetails.height, 10),
          tx: txDetails.tx,
        };
```

for both transactions.