### PR TITLE
Polish decorator types

### DIFF
--- a/packages/demo-protobuf/src/decorator.spec.ts
+++ b/packages/demo-protobuf/src/decorator.spec.ts
@@ -2,7 +2,7 @@
 import { assert } from "@cosmjs/utils";
 import { Message } from "protobufjs";
 
-import { CosmosField, CosmosMessage } from "./decorator";
+import { cosmosField, cosmosMessage } from "./decorator";
 import { Registry } from "./registry";
 
 describe("decorator demo", () => {
@@ -11,34 +11,34 @@ describe("decorator demo", () => {
     const typeUrl = "/demo.MsgDemo";
     const myRegistry = new Registry();
 
-    @CosmosMessage(myRegistry, nestedTypeUrl)
+    @cosmosMessage(myRegistry, nestedTypeUrl)
     class MsgNestedDemo extends Message<{}> {
-      @CosmosField.String(1)
+      @cosmosField.string(1)
       public readonly foo?: string;
     }
 
-    @CosmosMessage(myRegistry, typeUrl)
+    @cosmosMessage(myRegistry, typeUrl)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class MsgDemo extends Message<{}> {
-      @CosmosField.Boolean(1)
+      @cosmosField.boolean(1)
       public readonly booleanDemo?: boolean;
 
-      @CosmosField.String(2)
+      @cosmosField.string(2)
       public readonly stringDemo?: string;
 
-      @CosmosField.Bytes(3)
+      @cosmosField.bytes(3)
       public readonly bytesDemo?: Uint8Array;
 
-      @CosmosField.Int64(4)
+      @cosmosField.int64(4)
       public readonly int64Demo?: number;
 
-      @CosmosField.Uint64(5)
+      @cosmosField.uint64(5)
       public readonly uint64Demo?: number;
 
-      @CosmosField.RepeatedString(6)
+      @cosmosField.repeatedString(6)
       public readonly listDemo?: readonly string[];
 
-      @CosmosField.Nested(7, MsgNestedDemo)
+      @cosmosField.nested(7, MsgNestedDemo)
       public readonly nestedDemo?: MsgNestedDemo;
     }
 

--- a/packages/demo-protobuf/src/decorator.ts
+++ b/packages/demo-protobuf/src/decorator.ts
@@ -15,15 +15,20 @@ export function CosmosMessage(registry: Registry, typeUrl: string): TypeDecorato
   };
 }
 
+/**
+ * Like PropertyDecorator from lib.es5.d.ts but without symbol support in propertyKey.
+ */
+export type FieldDecorator = (target: object, propertyKey: string) => void;
+
 export const CosmosField = {
-  Boolean: (id: number) => Field.d<boolean>(id, "bool"),
+  Boolean: (id: number): FieldDecorator => Field.d<boolean>(id, "bool"),
 
-  String: (id: number) => Field.d<string>(id, "string"),
-  Bytes: (id: number) => Field.d<Uint8Array>(id, "bytes"),
+  String: (id: number): FieldDecorator => Field.d<string>(id, "string"),
+  Bytes: (id: number): FieldDecorator => Field.d<Uint8Array>(id, "bytes"),
 
-  Int64: (id: number) => Field.d<number>(id, "int64"),
-  Uint64: (id: number) => Field.d<number>(id, "uint64"),
+  Int64: (id: number): FieldDecorator => Field.d<number>(id, "int64"),
+  Uint64: (id: number): FieldDecorator => Field.d<number>(id, "uint64"),
 
-  RepeatedString: (id: number) => Field.d<string[]>(id, "string", "repeated"),
-  Nested: (id: number, ctor: Constructor<Message<{}>>) => Field.d(id, ctor),
+  RepeatedString: (id: number): FieldDecorator => Field.d<string[]>(id, "string", "repeated"),
+  Nested: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator => Field.d(id, ctor),
 };

--- a/packages/demo-protobuf/src/decorator.ts
+++ b/packages/demo-protobuf/src/decorator.ts
@@ -7,7 +7,7 @@ function getTypeName(typeUrl: string): string {
   return parts[parts.length - 1];
 }
 
-export function CosmosMessage(registry: Registry, typeUrl: string): TypeDecorator<any> {
+export function cosmosMessage(registry: Registry, typeUrl: string): TypeDecorator<any> {
   return (ctor: Constructor<Message<any>>) => {
     const typeName = getTypeName(typeUrl);
     const generatedType = util.decorateType(ctor, typeName);
@@ -20,15 +20,15 @@ export function CosmosMessage(registry: Registry, typeUrl: string): TypeDecorato
  */
 export type FieldDecorator = (target: object, propertyKey: string) => void;
 
-export const CosmosField = {
-  Boolean: (id: number): FieldDecorator => Field.d<boolean>(id, "bool"),
+export const cosmosField = {
+  boolean: (id: number): FieldDecorator => Field.d<boolean>(id, "bool"),
 
-  String: (id: number): FieldDecorator => Field.d<string>(id, "string"),
-  Bytes: (id: number): FieldDecorator => Field.d<Uint8Array>(id, "bytes"),
+  string: (id: number): FieldDecorator => Field.d<string>(id, "string"),
+  bytes: (id: number): FieldDecorator => Field.d<Uint8Array>(id, "bytes"),
 
-  Int64: (id: number): FieldDecorator => Field.d<number>(id, "int64"),
-  Uint64: (id: number): FieldDecorator => Field.d<number>(id, "uint64"),
+  int64: (id: number): FieldDecorator => Field.d<number>(id, "int64"),
+  uint64: (id: number): FieldDecorator => Field.d<number>(id, "uint64"),
 
-  RepeatedString: (id: number): FieldDecorator => Field.d<string[]>(id, "string", "repeated"),
-  Nested: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator => Field.d(id, ctor),
+  repeatedString: (id: number): FieldDecorator => Field.d<string[]>(id, "string", "repeated"),
+  nested: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator => Field.d(id, ctor),
 };

--- a/packages/demo-protobuf/types/decorator.d.ts
+++ b/packages/demo-protobuf/types/decorator.d.ts
@@ -1,12 +1,16 @@
 import { Constructor, Message, TypeDecorator } from "protobufjs";
 import { Registry } from "./registry";
 export declare function CosmosMessage(registry: Registry, typeUrl: string): TypeDecorator<any>;
+/**
+ * Like PropertyDecorator from lib.es5.d.ts but without symbol support in propertyKey.
+ */
+export declare type FieldDecorator = (target: object, propertyKey: string) => void;
 export declare const CosmosField: {
-  Boolean: (id: number) => import("protobufjs").FieldDecorator;
-  String: (id: number) => import("protobufjs").FieldDecorator;
-  Bytes: (id: number) => import("protobufjs").FieldDecorator;
-  Int64: (id: number) => import("protobufjs").FieldDecorator;
-  Uint64: (id: number) => import("protobufjs").FieldDecorator;
-  RepeatedString: (id: number) => import("protobufjs").FieldDecorator;
-  Nested: (id: number, ctor: Constructor<Message<{}>>) => import("protobufjs").FieldDecorator;
+  Boolean: (id: number) => FieldDecorator;
+  String: (id: number) => FieldDecorator;
+  Bytes: (id: number) => FieldDecorator;
+  Int64: (id: number) => FieldDecorator;
+  Uint64: (id: number) => FieldDecorator;
+  RepeatedString: (id: number) => FieldDecorator;
+  Nested: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
 };

--- a/packages/demo-protobuf/types/decorator.d.ts
+++ b/packages/demo-protobuf/types/decorator.d.ts
@@ -1,16 +1,16 @@
 import { Constructor, Message, TypeDecorator } from "protobufjs";
 import { Registry } from "./registry";
-export declare function CosmosMessage(registry: Registry, typeUrl: string): TypeDecorator<any>;
+export declare function cosmosMessage(registry: Registry, typeUrl: string): TypeDecorator<any>;
 /**
  * Like PropertyDecorator from lib.es5.d.ts but without symbol support in propertyKey.
  */
 export declare type FieldDecorator = (target: object, propertyKey: string) => void;
-export declare const CosmosField: {
-  Boolean: (id: number) => FieldDecorator;
-  String: (id: number) => FieldDecorator;
-  Bytes: (id: number) => FieldDecorator;
-  Int64: (id: number) => FieldDecorator;
-  Uint64: (id: number) => FieldDecorator;
-  RepeatedString: (id: number) => FieldDecorator;
-  Nested: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
+export declare const cosmosField: {
+  boolean: (id: number) => FieldDecorator;
+  string: (id: number) => FieldDecorator;
+  bytes: (id: number) => FieldDecorator;
+  int64: (id: number) => FieldDecorator;
+  uint64: (id: number) => FieldDecorator;
+  repeatedString: (id: number) => FieldDecorator;
+  nested: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
 };


### PR DESCRIPTION
- Add explicit return type for field decorators, which will be required by eslint7.
- Convert decorators to lowercase as in most examples I can find, especially https://www.typescriptlang.org/docs/handbook/decorators.html 