### PR TITLE
Decorate MsgSend

### DIFF
--- a/packages/demo-protobuf/package.json
+++ b/packages/demo-protobuf/package.json
@@ -41,6 +41,7 @@
     "protobufjs": "~6.9.0"
   },
   "devDependencies": {
+    "@cosmjs/encoding": "^0.20.0",
     "@cosmjs/utils": "^0.20.0"
   }
 }

--- a/packages/demo-protobuf/src/decorator.spec.ts
+++ b/packages/demo-protobuf/src/decorator.spec.ts
@@ -38,7 +38,7 @@ describe("decorator demo", () => {
       @cosmosField.repeatedString(6)
       public readonly listDemo?: readonly string[];
 
-      @cosmosField.nested(7, MsgNestedDemo)
+      @cosmosField.message(7, MsgNestedDemo)
       public readonly nestedDemo?: MsgNestedDemo;
     }
 

--- a/packages/demo-protobuf/src/decorator.ts
+++ b/packages/demo-protobuf/src/decorator.ts
@@ -29,6 +29,9 @@ export const cosmosField = {
   int64: (id: number): FieldDecorator => Field.d<number>(id, "int64"),
   uint64: (id: number): FieldDecorator => Field.d<number>(id, "uint64"),
 
-  repeatedString: (id: number): FieldDecorator => Field.d<string[]>(id, "string", "repeated"),
   nested: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator => Field.d(id, ctor),
+
+  repeatedString: (id: number): FieldDecorator => Field.d<string[]>(id, "string", "repeated"),
+  repeatedNested: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator =>
+    Field.d(id, ctor, "repeated"),
 };

--- a/packages/demo-protobuf/src/decorator.ts
+++ b/packages/demo-protobuf/src/decorator.ts
@@ -29,9 +29,9 @@ export const cosmosField = {
   int64: (id: number): FieldDecorator => Field.d<number>(id, "int64"),
   uint64: (id: number): FieldDecorator => Field.d<number>(id, "uint64"),
 
-  nested: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator => Field.d(id, ctor),
+  message: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator => Field.d(id, ctor),
 
   repeatedString: (id: number): FieldDecorator => Field.d<string[]>(id, "string", "repeated"),
-  repeatedNested: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator =>
+  repeatedMessage: (id: number, ctor: Constructor<Message<{}>>): FieldDecorator =>
     Field.d(id, ctor, "repeated"),
 };

--- a/packages/demo-protobuf/src/msgs.spec.ts
+++ b/packages/demo-protobuf/src/msgs.spec.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { fromHex } from "@cosmjs/encoding";
+
+import { cosmos_sdk as cosmosSdk } from "./generated/codecimpl";
+import { Coin, MsgSend } from "./msgs";
+
+describe("msgs", () => {
+  it("encodes decorated MsgSend equally to static code", () => {
+    const alice = fromHex("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    const bob = fromHex("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+    const amount = [
+      new Coin({ denom: "utoken", amount: "123" }),
+      new Coin({ denom: "ustake", amount: "654" }),
+    ];
+    const donation = new MsgSend({ from_address: alice, to_address: bob, amount });
+
+    const expected = cosmosSdk.x.bank.v1.MsgSend.encode(
+      cosmosSdk.x.bank.v1.MsgSend.create({
+        fromAddress: alice,
+        toAddress: bob,
+        amount: [
+          cosmosSdk.v1.Coin.create({
+            denom: "utoken",
+            amount: "123",
+          }),
+          cosmosSdk.v1.Coin.create({
+            denom: "ustake",
+            amount: "654",
+          }),
+        ],
+      }),
+    ).finish();
+
+    const encoded = MsgSend.encode(donation).finish();
+    expect(encoded).toEqual(expected);
+  });
+});

--- a/packages/demo-protobuf/src/msgs.ts
+++ b/packages/demo-protobuf/src/msgs.ts
@@ -1,0 +1,27 @@
+import { Message } from "protobufjs";
+
+import { cosmosField, cosmosMessage } from "./decorator";
+import { Registry } from "./registry";
+
+export const defaultRegistry = new Registry();
+
+@cosmosMessage(defaultRegistry, "/cosmos.Coin")
+export class Coin extends Message<{}> {
+  @cosmosField.string(1)
+  public readonly denom?: string;
+
+  @cosmosField.string(2)
+  public readonly amount?: string;
+}
+
+@cosmosMessage(defaultRegistry, "/cosmos.bank.MsgSend")
+export class MsgSend extends Message<{}> {
+  @cosmosField.bytes(1)
+  public readonly from_address?: Uint8Array;
+
+  @cosmosField.bytes(2)
+  public readonly to_address?: Uint8Array;
+
+  @cosmosField.repeatedNested(3, Coin)
+  public readonly amount?: readonly Coin[];
+}

--- a/packages/demo-protobuf/src/msgs.ts
+++ b/packages/demo-protobuf/src/msgs.ts
@@ -22,6 +22,6 @@ export class MsgSend extends Message<{}> {
   @cosmosField.bytes(2)
   public readonly to_address?: Uint8Array;
 
-  @cosmosField.repeatedNested(3, Coin)
+  @cosmosField.repeatedMessage(3, Coin)
   public readonly amount?: readonly Coin[];
 }

--- a/packages/demo-protobuf/types/decorator.d.ts
+++ b/packages/demo-protobuf/types/decorator.d.ts
@@ -11,7 +11,7 @@ export declare const cosmosField: {
   bytes: (id: number) => FieldDecorator;
   int64: (id: number) => FieldDecorator;
   uint64: (id: number) => FieldDecorator;
-  nested: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
+  message: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
   repeatedString: (id: number) => FieldDecorator;
-  repeatedNested: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
+  repeatedMessage: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
 };

--- a/packages/demo-protobuf/types/decorator.d.ts
+++ b/packages/demo-protobuf/types/decorator.d.ts
@@ -11,6 +11,7 @@ export declare const cosmosField: {
   bytes: (id: number) => FieldDecorator;
   int64: (id: number) => FieldDecorator;
   uint64: (id: number) => FieldDecorator;
-  repeatedString: (id: number) => FieldDecorator;
   nested: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
+  repeatedString: (id: number) => FieldDecorator;
+  repeatedNested: (id: number, ctor: Constructor<Message<{}>>) => FieldDecorator;
 };

--- a/packages/demo-protobuf/types/msgs.d.ts
+++ b/packages/demo-protobuf/types/msgs.d.ts
@@ -1,0 +1,12 @@
+import { Message } from "protobufjs";
+import { Registry } from "./registry";
+export declare const defaultRegistry: Registry;
+export declare class Coin extends Message<{}> {
+  readonly denom?: string;
+  readonly amount?: string;
+}
+export declare class MsgSend extends Message<{}> {
+  readonly from_address?: Uint8Array;
+  readonly to_address?: Uint8Array;
+  readonly amount?: readonly Coin[];
+}


### PR DESCRIPTION
This example shows how 9 lines of decorated code replace 96 lines of autogenerated code. It shows how easy it can be to register custom types.