### PR TITLE
Fix: error TS2304: cannot find name 'window'

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "lib": ["dom", "es5", "es6"],
     "outDir": "build",
     "rootDir": "src"
   },


### PR DESCRIPTION
Fixes error that appears when running command `yarn build`
```
yarn run v1.22.4
$ tsc
../../../node_modules/@types/reach__router/index.d.ts:12:30 - error TS2304: Cannot find name 'Window'.

12 export type WindowLocation = Window['location'] & HLocation;
```