### PR TITLE
Stabilize ID test for createJsonRpcRequest

### DIFF
--- a/packages/tendermint-rpc/src/jsonrpc.spec.ts
+++ b/packages/tendermint-rpc/src/jsonrpc.spec.ts
@@ -5,7 +5,7 @@ describe("jsonrpc", () => {
     it("generates proper object with correct method", () => {
       const request = createJsonRpcRequest("do_something");
       expect(request.jsonrpc).toEqual("2.0");
-      expect(request.id.toString()).toMatch(/^[0-9]{10,12}$/);
+      expect(request.id.toString()).toMatch(/^[1-9]{12}$/);
       expect(request.method).toEqual("do_something");
     });
 

--- a/packages/tendermint-rpc/src/jsonrpc.ts
+++ b/packages/tendermint-rpc/src/jsonrpc.ts
@@ -1,12 +1,15 @@
 import { JsonRpcRequest } from "@cosmjs/json-rpc";
 
-const numbers = "0123456789";
+const numbersWithoutZero = "123456789";
 
 /** generates a random numeric character  */
 function randomNumericChar(): string {
-  return numbers[Math.floor(Math.random() * numbers.length)];
+  return numbersWithoutZero[Math.floor(Math.random() * numbersWithoutZero.length)];
 }
 
+/**
+ * An (absolutely not cryptographically secure) random integer > 0.
+ */
 function randomId(): number {
   return parseInt(
     Array.from({ length: 12 })


### PR DESCRIPTION
Avoid test fails like

```
Chrome Headless 81.0.4044.113 (Linux x86_64): Executed 29 of 53 SUCCESS (0 secs / 28.199 secs)
Chrome Headless 81.0.4044.113 (Linux x86_64): Executed 30 of 53 SUCCESS (0 secs / 28.199 secs)
Chrome Headless 81.0.4044.113 (Linux x86_64): Executed 31 of 53 SUCCESS (0 secs / 28.199 secs)
Chrome Headless 81.0.4044.113 (Linux x86_64) jsonrpc createJsonRpcRequest generates proper object with correct method FAILED
	Error: Expected '756321270' to match /^[0-9]{10,12}$/.
	    at <Jasmine>
	    at UserContext.eval (webpack:///./build/jsonrpc.spec.js?:9:43)
	    at <Jasmine>
Chrome Headless 81.0.4044.113 (Linux x86_64): Executed 32 of 53 (1 FAILED) (0 secs / 28.202 secs)
Chrome Headless 81.0.4044.113 (Linux x86_64) jsonrpc createJsonRpcRequest generates proper object with correct method FAILED
	Error: Expected '756321270' to match /^[0-9]{10,12}$/.
	    at <Jasmine>
	    at UserContext.eval (webpack:///./build/jsonrpc.spec.js?:9:43)
	    at <Jasmine>
Chrome Headless 81.0.4044.113 (Linux x86_64): Executed 33 of 53 (1 FAILED) (0 secs / 28.203 secs)
Chrome Headless 81.0.4044.113 (Linux x86_64): Executed 34 of 53 (1 FAILED) (0 secs / 28.204 secs)
Chrome Headless 81.0.4044.113 (Linux x86_64): Executed 35 of 53 (1 FAILED) (0 secs / 28.212 secs)
```

https://app.circleci.com/pipelines/github/CosmWasm/cosmjs/748/workflows/d332d4a7-8baf-44e1-9d68-1e72718a62c3/jobs/2467