### PR TITLE
Decode protobuf Buffers as Uint8Arrays

### DIFF
--- a/packages/proto-signing/src/magic.spec.ts
+++ b/packages/proto-signing/src/magic.spec.ts
@@ -76,8 +76,7 @@ describe("registry magic demo", () => {
     expect(msgDemoDecoded).toBeInstanceOf(MsgMagic);
     expect(msgDemoDecoded.booleanDemo).toEqual(msgDemoFields.booleanDemo);
     expect(msgDemoDecoded.stringDemo).toEqual(msgDemoFields.stringDemo);
-    // bytesDemo decodes to a Buffer in Node
-    expect(Uint8Array.from(msgDemoDecoded.bytesDemo!)).toEqual(msgDemoFields.bytesDemo);
+    expect(msgDemoDecoded.bytesDemo).toEqual(msgDemoFields.bytesDemo);
     // int64Demo and uint64Demo decode to Long in Node
     expect(Number(msgDemoDecoded.int64Demo)).toEqual(msgDemoFields.int64Demo);
     expect(Number(msgDemoDecoded.uint64Demo)).toEqual(msgDemoFields.uint64Demo);

--- a/packages/proto-signing/src/registry.ts
+++ b/packages/proto-signing/src/registry.ts
@@ -68,7 +68,7 @@ export class Registry {
     }
     const type = this.lookupTypeWithError(typeUrl);
     const created = type.create(value);
-    return type.encode(created).finish();
+    return Uint8Array.from(type.encode(created).finish());
   }
 
   public encodeTxBody(txBodyFields: TxBodyValue): Uint8Array {
@@ -86,7 +86,7 @@ export class Registry {
       ...txBodyFields,
       messages: wrappedMessages,
     });
-    return TxBody.encode(txBody).finish();
+    return Uint8Array.from(TxBody.encode(txBody).finish());
   }
 
   public decode({ typeUrl, value }: DecodeObject): any {
@@ -94,7 +94,13 @@ export class Registry {
       return this.decodeTxBody(value);
     }
     const type = this.lookupTypeWithError(typeUrl);
-    return type.decode(value);
+    const decoded = type.decode(value);
+    Object.entries(decoded).forEach(([key, val]: [string, any]) => {
+      if (typeof Buffer !== "undefined" && typeof Buffer.isBuffer !== "undefined" && Buffer.isBuffer(val)) {
+        decoded[key] = Uint8Array.from(val);
+      }
+    });
+    return decoded;
   }
 
   public decodeTxBody(txBody: Uint8Array): cosmosSdk.tx.v1.TxBody {


### PR DESCRIPTION
Closes #239

I don't see a straightforward way to wrap `Field`. This is an 80/20 solution.﻿
