### PR TITLE
Add cosmos-sdk message types

### DIFF
--- a/packages/sdk38/src/msgs.ts
+++ b/packages/sdk38/src/msgs.ts
@@ -6,7 +6,11 @@ export interface Msg {
   readonly value: any;
 }
 
-/** A Cosmos SDK token transfer message */
+// auth (no messages) - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/auth/auth.proto
+
+// bank - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/bank/bank.proto
+
+/** A high level transaction of the coin module */
 export interface MsgSend extends Msg {
   readonly type: "cosmos-sdk/MsgSend";
   readonly value: {
@@ -22,8 +26,261 @@ export function isMsgSend(msg: Msg): msg is MsgSend {
   return (msg as MsgSend).type === "cosmos-sdk/MsgSend";
 }
 
+interface Input {
+  /** Bech32 account address */
+  readonly address: string;
+  readonly coins: readonly Coin[];
+}
+
+interface Output {
+  /** Bech32 account address */
+  readonly address: string;
+  readonly coins: readonly Coin[];
+}
+
+/** A high level transaction of the coin module */
+export interface MsgMultiSend extends Msg {
+  readonly type: "cosmos-sdk/MsgMultiSend";
+  readonly value: {
+    readonly inputs: readonly Input[];
+    readonly outputs: readonly Output[];
+  };
+}
+
+export function isMsgMultiSend(msg: Msg): msg is MsgMultiSend {
+  return (msg as MsgMultiSend).type === "cosmos-sdk/MsgMultiSend";
+}
+
+// crisis - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/crisis/crisis.proto
+
+/** Verifies a particular invariance */
+export interface MsgVerifyInvariant extends Msg {
+  readonly type: "cosmos-sdk/MsgVerifyInvariant";
+  readonly value: {
+    /** Bech32 account address */
+    readonly sender: string;
+    readonly invariant_module_name: string;
+    readonly invariant_route: string;
+  };
+}
+
+export function isMsgVerifyInvariant(msg: Msg): msg is MsgVerifyInvariant {
+  return (msg as MsgVerifyInvariant).type === "cosmos-sdk/MsgVerifyInvariant";
+}
+
+// distribution - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/distribution/distribution.proto
+
+/** Changes the withdraw address for a delegator (or validator self-delegation) */
+export interface MsgSetWithdrawAddress extends Msg {
+  readonly type: "cosmos-sdk/MsgSetWithdrawAddress";
+  readonly value: {
+    /** Bech32 account address */
+    readonly delegator_address: string;
+    /** Bech32 account address */
+    readonly withdraw_address: string;
+  };
+}
+
+export function isMsgSetWithdrawAddress(msg: Msg): msg is MsgSetWithdrawAddress {
+  return (msg as MsgSetWithdrawAddress).type === "cosmos-sdk/MsgSetWithdrawAddress";
+}
+
+/** Message for delegation withdraw from a single validator */
+export interface MsgWithdrawDelegatorReward extends Msg {
+  readonly type: "cosmos-sdk/MsgWithdrawDelegatorReward";
+  readonly value: {
+    /** Bech32 account address */
+    readonly delegator_address: string;
+    /** Bech32 account address */
+    readonly validator_address: string;
+  };
+}
+
+export function isMsgWithdrawDelegatorReward(msg: Msg): msg is MsgWithdrawDelegatorReward {
+  return (msg as MsgWithdrawDelegatorReward).type === "cosmos-sdk/MsgWithdrawDelegatorReward";
+}
+
+/** Message for validator withdraw */
+export interface MsgWithdrawValidatorCommission extends Msg {
+  readonly type: "cosmos-sdk/MsgWithdrawValidatorCommission";
+  readonly value: {
+    /** Bech32 account address */
+    readonly validator_address: string;
+  };
+}
+
+export function isMsgWithdrawValidatorCommission(msg: Msg): msg is MsgWithdrawValidatorCommission {
+  return (msg as MsgWithdrawValidatorCommission).type === "cosmos-sdk/MsgWithdrawValidatorCommission";
+}
+
+/** Allows an account to directly fund the community pool. */
+export interface MsgFundCommunityPool extends Msg {
+  readonly type: "cosmos-sdk/MsgFundCommunityPool";
+  readonly value: {
+    readonly amount: readonly Coin[];
+    /** Bech32 account address */
+    readonly depositor: string;
+  };
+}
+
+export function isMsgFundCommunityPool(msg: Msg): msg is MsgFundCommunityPool {
+  return (msg as MsgFundCommunityPool).type === "cosmos-sdk/MsgFundCommunityPool";
+}
+
+// evidence - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/evidence/evidence.proto
+
+interface Any {
+  readonly type_url: string;
+  readonly value: Uint8Array;
+}
+
+/** Supports submitting arbitrary evidence */
+export interface MsgSubmitEvidence {
+  readonly type: "cosmos-sdk/MsgSubmitEvidence";
+  readonly value: {
+    /** Bech32 account address */
+    readonly submitter: string;
+    readonly evidence: Any;
+  };
+}
+
+export function isMsgSubmitEvidence(msg: Msg): msg is MsgSubmitEvidence {
+  return (msg as MsgSubmitEvidence).type === "cosmos-sdk/MsgSubmitEvidence";
+}
+
+// gov - https://github.com/cosmos/cosmos-sdk/blob/efa73c7edb31a7bd65786501da213b294f89267a/proto/cosmos/gov/gov.proto
+
+/** Supports submitting arbitrary proposal content. */
+export interface MsgSubmitProposal {
+  readonly type: "cosmos-sdk/MsgSubmitProposal";
+  readonly value: {
+    readonly content: Any;
+    readonly initial_deposit: readonly Coin[];
+    /** Bech32 account address */
+    readonly proposer: string;
+  };
+}
+
+export function isMsgSubmitProposal(msg: Msg): msg is MsgSubmitProposal {
+  return (msg as MsgSubmitProposal).type === "cosmos-sdk/MsgSubmitProposal";
+}
+
+enum VoteOption {
+  VoteOptionUnspecified,
+  VoteOptionYes,
+  VoteOptionAbstain,
+  VoteOptionNo,
+  VoteOptionNoWithVeto,
+}
+
+/** Casts a vote */
+export interface MsgVote {
+  readonly type: "cosmos-sdk/MsgVote";
+  readonly value: {
+    readonly proposal_id: number;
+    /** Bech32 account address */
+    readonly voter: string;
+    readonly option: VoteOption;
+  };
+}
+
+export function isMsgVote(msg: Msg): msg is MsgVote {
+  return (msg as MsgVote).type === "cosmos-sdk/MsgVote";
+}
+
+/** Submits a deposit to an existing proposal */
+export interface MsgDeposit {
+  readonly type: "cosmos-sdk/MsgDeposit";
+  readonly value: {
+    readonly proposal_id: number;
+    /** Bech32 account address */
+    readonly depositor: string;
+    readonly amount: readonly Coin[];
+  };
+}
+
+export function isMsgDeposit(msg: Msg): msg is MsgDeposit {
+  return (msg as MsgDeposit).type === "cosmos-sdk/MsgDeposit";
+}
+
+// ibc
+
+// mint (no messages) - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/mint/mint.proto
+
+// params (no messages) - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/params/params.proto
+
+// slashing - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/slashing/slashing.proto
+
+/** Unjails a jailed validator */
+export interface MsgUnjail {
+  readonly type: "cosmos-sdk/MsgUnjail";
+  readonly value: {
+    /** Bech32 account address */
+    readonly validator_addr: string;
+  };
+}
+
+export function isMsgUnjail(msg: Msg): msg is MsgUnjail {
+  return (msg as MsgUnjail).type === "cosmos-sdk/MsgUnjail";
+}
+
+// staking - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/staking/staking.proto
+
+/** The initial commission rates to be used for creating a validator */
+interface CommissionRates {
+  readonly rate: string;
+  readonly max_rate: string;
+  readonly max_change_rate: string;
+}
+
+/** A validator description. */
+interface Description {
+  readonly moniker: string;
+  readonly identity: string;
+  readonly website: string;
+  readonly security_contact: string;
+  readonly details: string;
+}
+
+/** Creates a new validator. */
+export interface MsgCreateValidator {
+  readonly type: "cosmos-sdk/MsgCreateValidator";
+  readonly value: {
+    readonly description: Description;
+    readonly commission: CommissionRates;
+    readonly min_self_delegation: string;
+    /** Bech32 encoded delegator address */
+    readonly delegator_address: string;
+    /** Bech32 encoded validator address */
+    readonly validator_address: string;
+    /** Bech32 encoded public key */
+    readonly pubkey: string;
+    readonly value: Coin;
+  };
+}
+
+export function isMsgCreateValidator(msg: Msg): msg is MsgCreateValidator {
+  return (msg as MsgCreateValidator).type === "cosmos-sdk/MsgCreateValidator";
+}
+
+/** Edits an existing validator. */
+export interface MsgEditValidator {
+  readonly type: "cosmos-sdk/MsgEditValidator";
+  readonly value: {
+    readonly description: Description;
+    /** Bech32 encoded validator address */
+    readonly validator_address: string;
+    readonly commission_rate: string;
+    readonly min_self_delegation: string;
+  };
+}
+
+export function isMsgEditValidator(msg: Msg): msg is MsgEditValidator {
+  return (msg as MsgEditValidator).type === "cosmos-sdk/MsgEditValidator";
+}
+
 /**
- * A Cosmos SDK MsgDelegate
+ * Performs a delegation from a delegate to a validator.
  *
  * @see https://docs.cosmos.network/master/modules/staking/03_messages.html#msgdelegate
  */
@@ -41,3 +298,39 @@ export interface MsgDelegate extends Msg {
 export function isMsgDelegate(msg: Msg): msg is MsgDelegate {
   return (msg as MsgDelegate).type === "cosmos-sdk/MsgDelegate";
 }
+
+/** Performs a redelegation from a delegate and source validator to a destination validator */
+export interface MsgBeginRedelegate {
+  readonly type: "cosmos-sdk/MsgBeginRedelegate";
+  readonly value: {
+    /** Bech32 encoded delegator address */
+    readonly delegator_address: string;
+    /** Bech32 encoded source validator address */
+    readonly validator_src_address: string;
+    /** Bech32 encoded destination validator address */
+    readonly validator_dst_address: string;
+    readonly amount: Coin;
+  };
+}
+
+export function isMsgBeginRedelegate(msg: Msg): msg is MsgBeginRedelegate {
+  return (msg as MsgBeginRedelegate).type === "cosmos-sdk/MsgBeginRedelegate";
+}
+
+/** Performs an undelegation from a delegate and a validator */
+export interface MsgUndelegate {
+  readonly type: "cosmos-sdk/MsgUndelegate";
+  readonly value: {
+    /** Bech32 encoded delegator address */
+    readonly delegator_address: string;
+    /** Bech32 encoded validator address */
+    readonly validator_address: string;
+    readonly amount: Coin;
+  };
+}
+
+export function isMsgUndelegate(msg: Msg): msg is MsgUndelegate {
+  return (msg as MsgUndelegate).type === "cosmos-sdk/MsgUndelegate";
+}
+
+// upgrade (no messages) - see https://github.com/cosmos/cosmos-sdk/blob/efa73c7/proto/cosmos/upgrade/upgrade.proto

--- a/packages/sdk38/types/msgs.d.ts
+++ b/packages/sdk38/types/msgs.d.ts
@@ -3,7 +3,7 @@ export interface Msg {
   readonly type: string;
   readonly value: any;
 }
-/** A Cosmos SDK token transfer message */
+/** A high level transaction of the coin module */
 export interface MsgSend extends Msg {
   readonly type: "cosmos-sdk/MsgSend";
   readonly value: {
@@ -15,8 +15,185 @@ export interface MsgSend extends Msg {
   };
 }
 export declare function isMsgSend(msg: Msg): msg is MsgSend;
+interface Input {
+  /** Bech32 account address */
+  readonly address: string;
+  readonly coins: readonly Coin[];
+}
+interface Output {
+  /** Bech32 account address */
+  readonly address: string;
+  readonly coins: readonly Coin[];
+}
+/** A high level transaction of the coin module */
+export interface MsgMultiSend extends Msg {
+  readonly type: "cosmos-sdk/MsgMultiSend";
+  readonly value: {
+    readonly inputs: readonly Input[];
+    readonly outputs: readonly Output[];
+  };
+}
+export declare function isMsgMultiSend(msg: Msg): msg is MsgMultiSend;
+/** Verifies a particular invariance */
+export interface MsgVerifyInvariant extends Msg {
+  readonly type: "cosmos-sdk/MsgVerifyInvariant";
+  readonly value: {
+    /** Bech32 account address */
+    readonly sender: string;
+    readonly invariant_module_name: string;
+    readonly invariant_route: string;
+  };
+}
+export declare function isMsgVerifyInvariant(msg: Msg): msg is MsgVerifyInvariant;
+/** Changes the withdraw address for a delegator (or validator self-delegation) */
+export interface MsgSetWithdrawAddress extends Msg {
+  readonly type: "cosmos-sdk/MsgSetWithdrawAddress";
+  readonly value: {
+    /** Bech32 account address */
+    readonly delegator_address: string;
+    /** Bech32 account address */
+    readonly withdraw_address: string;
+  };
+}
+export declare function isMsgSetWithdrawAddress(msg: Msg): msg is MsgSetWithdrawAddress;
+/** Message for delegation withdraw from a single validator */
+export interface MsgWithdrawDelegatorReward extends Msg {
+  readonly type: "cosmos-sdk/MsgWithdrawDelegatorReward";
+  readonly value: {
+    /** Bech32 account address */
+    readonly delegator_address: string;
+    /** Bech32 account address */
+    readonly validator_address: string;
+  };
+}
+export declare function isMsgWithdrawDelegatorReward(msg: Msg): msg is MsgWithdrawDelegatorReward;
+/** Message for validator withdraw */
+export interface MsgWithdrawValidatorCommission extends Msg {
+  readonly type: "cosmos-sdk/MsgWithdrawValidatorCommission";
+  readonly value: {
+    /** Bech32 account address */
+    readonly validator_address: string;
+  };
+}
+export declare function isMsgWithdrawValidatorCommission(msg: Msg): msg is MsgWithdrawValidatorCommission;
+/** Allows an account to directly fund the community pool. */
+export interface MsgFundCommunityPool extends Msg {
+  readonly type: "cosmos-sdk/MsgFundCommunityPool";
+  readonly value: {
+    readonly amount: readonly Coin[];
+    /** Bech32 account address */
+    readonly depositor: string;
+  };
+}
+export declare function isMsgFundCommunityPool(msg: Msg): msg is MsgFundCommunityPool;
+interface Any {
+  readonly type_url: string;
+  readonly value: Uint8Array;
+}
+/** Supports submitting arbitrary evidence */
+export interface MsgSubmitEvidence {
+  readonly type: "cosmos-sdk/MsgSubmitEvidence";
+  readonly value: {
+    /** Bech32 account address */
+    readonly submitter: string;
+    readonly evidence: Any;
+  };
+}
+export declare function isMsgSubmitEvidence(msg: Msg): msg is MsgSubmitEvidence;
+/** Supports submitting arbitrary proposal content. */
+export interface MsgSubmitProposal {
+  readonly type: "cosmos-sdk/MsgSubmitProposal";
+  readonly value: {
+    readonly content: Any;
+    readonly initial_deposit: readonly Coin[];
+    /** Bech32 account address */
+    readonly proposer: string;
+  };
+}
+export declare function isMsgSubmitProposal(msg: Msg): msg is MsgSubmitProposal;
+declare enum VoteOption {
+  VoteOptionUnspecified = 0,
+  VoteOptionYes = 1,
+  VoteOptionAbstain = 2,
+  VoteOptionNo = 3,
+  VoteOptionNoWithVeto = 4,
+}
+/** Casts a vote */
+export interface MsgVote {
+  readonly type: "cosmos-sdk/MsgVote";
+  readonly value: {
+    readonly proposal_id: number;
+    /** Bech32 account address */
+    readonly voter: string;
+    readonly option: VoteOption;
+  };
+}
+export declare function isMsgVote(msg: Msg): msg is MsgVote;
+/** Submits a deposit to an existing proposal */
+export interface MsgDeposit {
+  readonly type: "cosmos-sdk/MsgDeposit";
+  readonly value: {
+    readonly proposal_id: number;
+    /** Bech32 account address */
+    readonly depositor: string;
+    readonly amount: readonly Coin[];
+  };
+}
+export declare function isMsgDeposit(msg: Msg): msg is MsgDeposit;
+/** Unjails a jailed validator */
+export interface MsgUnjail {
+  readonly type: "cosmos-sdk/MsgUnjail";
+  readonly value: {
+    /** Bech32 account address */
+    readonly validator_addr: string;
+  };
+}
+export declare function isMsgUnjail(msg: Msg): msg is MsgUnjail;
+/** The initial commission rates to be used for creating a validator */
+interface CommissionRates {
+  readonly rate: string;
+  readonly max_rate: string;
+  readonly max_change_rate: string;
+}
+/** A validator description. */
+interface Description {
+  readonly moniker: string;
+  readonly identity: string;
+  readonly website: string;
+  readonly security_contact: string;
+  readonly details: string;
+}
+/** Creates a new validator. */
+export interface MsgCreateValidator {
+  readonly type: "cosmos-sdk/MsgCreateValidator";
+  readonly value: {
+    readonly description: Description;
+    readonly commission: CommissionRates;
+    readonly min_self_delegation: string;
+    /** Bech32 encoded delegator address */
+    readonly delegator_address: string;
+    /** Bech32 encoded validator address */
+    readonly validator_address: string;
+    /** Bech32 encoded public key */
+    readonly pubkey: string;
+    readonly value: Coin;
+  };
+}
+export declare function isMsgCreateValidator(msg: Msg): msg is MsgCreateValidator;
+/** Edits an existing validator. */
+export interface MsgEditValidator {
+  readonly type: "cosmos-sdk/MsgEditValidator";
+  readonly value: {
+    readonly description: Description;
+    /** Bech32 encoded validator address */
+    readonly validator_address: string;
+    readonly commission_rate: string;
+    readonly min_self_delegation: string;
+  };
+}
+export declare function isMsgEditValidator(msg: Msg): msg is MsgEditValidator;
 /**
- * A Cosmos SDK MsgDelegate
+ * Performs a delegation from a delegate to a validator.
  *
  * @see https://docs.cosmos.network/master/modules/staking/03_messages.html#msgdelegate
  */
@@ -31,3 +208,30 @@ export interface MsgDelegate extends Msg {
   };
 }
 export declare function isMsgDelegate(msg: Msg): msg is MsgDelegate;
+/** Performs a redelegation from a delegate and source validator to a destination validator */
+export interface MsgBeginRedelegate {
+  readonly type: "cosmos-sdk/MsgBeginRedelegate";
+  readonly value: {
+    /** Bech32 encoded delegator address */
+    readonly delegator_address: string;
+    /** Bech32 encoded source validator address */
+    readonly validator_src_address: string;
+    /** Bech32 encoded destination validator address */
+    readonly validator_dst_address: string;
+    readonly amount: Coin;
+  };
+}
+export declare function isMsgBeginRedelegate(msg: Msg): msg is MsgBeginRedelegate;
+/** Performs an undelegation from a delegate and a validator */
+export interface MsgUndelegate {
+  readonly type: "cosmos-sdk/MsgUndelegate";
+  readonly value: {
+    /** Bech32 encoded delegator address */
+    readonly delegator_address: string;
+    /** Bech32 encoded validator address */
+    readonly validator_address: string;
+    readonly amount: Coin;
+  };
+}
+export declare function isMsgUndelegate(msg: Msg): msg is MsgUndelegate;
+export {};


### PR DESCRIPTION
Part of #276

Cosmos SDK message types, not including IBC.

Some of the modules in the checklist didn't seem to have any messages. I was also unsure about the types for a lot of values and didn't see an easy way to test they're right without writing a huge amount of test code.

I copied and adjusted lots of comments, but they mostly seem superfluous.