### PR TITLE
Break && lists into separate commands

### DIFF
--- a/scripts/simapp/generate_template.sh
+++ b/scripts/simapp/generate_template.sh
@@ -9,8 +9,10 @@ source "$SCRIPT_DIR"/env
 
 rm -rf "$SCRIPT_DIR/template"
 mkdir "$SCRIPT_DIR/template"
-cp setup.sh "$SCRIPT_DIR/template/" && chmod +x "$SCRIPT_DIR/template/setup.sh"
-cp run_simd.sh "$SCRIPT_DIR/template/" && chmod +x "$SCRIPT_DIR/template/run_simd.sh"
+cp setup.sh "$SCRIPT_DIR/template/"
+chmod +x "$SCRIPT_DIR/template/setup.sh"
+cp run_simd.sh "$SCRIPT_DIR/template/"
+chmod +x "$SCRIPT_DIR/template/run_simd.sh"
 
 # The usage of the accounts below is documented in README.md of this directory
 docker run --rm \


### PR DESCRIPTION
A shell script with set -o errexit is not stopped when there is an error in the first command of commandA && commandB because

> The shell does not exit if the command that fails is ... part of any command executed in a && or || list

https://unix.stackexchange.com/a/490177