### PR TITLE
Start simapp's in-process API

### DIFF
--- a/scripts/simapp/start.sh
+++ b/scripts/simapp/start.sh
@@ -4,6 +4,8 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 
 TENDERMINT_PORT_GUEST="26657"
 TENDERMINT_PORT_HOST="26657"
+API_PORT_GUEST="1317"
+API_PORT_HOST="1318"
 
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 # shellcheck source=./env
@@ -21,6 +23,7 @@ docker volume rm -f simapp_data
 docker run --rm \
   --name "$CONTAINER_NAME" \
   -p "$TENDERMINT_PORT_HOST":"$TENDERMINT_PORT_GUEST" \
+  -p "$API_PORT_HOST":"$API_PORT_GUEST" \
   --mount type=bind,source="$SCRIPT_DIR/template",target=/template \
   --mount type=volume,source=simapp_data,target=/root \
   "$REPOSITORY:$VERSION" \

--- a/scripts/simapp/template/.simapp/config/app.toml
+++ b/scripts/simapp/template/.simapp/config/app.toml
@@ -78,7 +78,7 @@ global-labels = [
 [api]
 
 # Enable defines if the API server should be enabled.
-enable = false
+enable = true
 
 # Swagger defines if swagger documentation should automatically be registered.
 swagger = false
@@ -99,4 +99,4 @@ rpc-write-timeout = 0
 rpc-max-body-bytes = 1000000
 
 # EnableUnsafeCORS defines if CORS should be enabled (unsafe - use it at your own risk)
-enabled-unsafe-cors = false
+enabled-unsafe-cors = true


### PR DESCRIPTION
With this change, we can use the HTTP API for debugging some stuff, e.g. `GET http://localhost:1318/auth/accounts/cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6`:

```json
{
  "height": "0",
  "result": {
    "type": "cosmos-sdk/BaseAccount",
    "value": {
      "address": "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6",
      "account_number": "1"
    }
  }
}
```

The missing sequence indicates it is 0.