### PR TITLE
Internalize SignDoc and omitDefaults for sign bytes creation

### DIFF
--- a/packages/proto-signing/src/index.ts
+++ b/packages/proto-signing/src/index.ts
@@ -1,4 +1,3 @@
-export { omitDefaults } from "./adr27";
 export { Coin } from "./msgs";
 export { cosmosField } from "./decorator";
 export { Registry } from "./registry";

--- a/packages/proto-signing/src/signing.spec.ts
+++ b/packages/proto-signing/src/signing.spec.ts
@@ -30,7 +30,7 @@ const faucet = {
 // simd tx bank send --sign-mode direct --chain-id simd-testing testgen cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu 1234567ucosm -b block
 const testVectors = [
   {
-    sequenceNumber: 0,
+    sequence: 0,
     signedTxBytes:
       "0a580a560a142f636f736d6f732e62616e6b2e4d736753656e64123e0a140d82b1e7c96dbfa42462fe612932e6bff111d51b12140102030405060708090a0b0c0d0e0f10111213141a100a0575636f736d12073132333435363712330a2b0a230a21034f04181eeba35391b858633a765c4a0c189697b40d216354d50890d350c7029012040a020801120410c09a0c1a40692d88f681d5d69924a53668e8ecec535ca0ca170d1febfb1dd87de9959b07340427d6bba22526d6c30cc622f27dc5eb1ce04cfc0ff98716154066ec69db62e5",
     signBytes:
@@ -40,7 +40,7 @@ const testVectors = [
   },
 
   {
-    sequenceNumber: 1,
+    sequence: 1,
     signedTxBytes:
       "0a580a560a142f636f736d6f732e62616e6b2e4d736753656e64123e0a140d82b1e7c96dbfa42462fe612932e6bff111d51b12140102030405060708090a0b0c0d0e0f10111213141a100a0575636f736d12073132333435363712330a2b0a230a21034f04181eeba35391b858633a765c4a0c189697b40d216354d50890d350c7029012040a020801120410c09a0c1a40811c3c7dd85b1478b15e3cc710503045559d805d2bf538e5015dbcd868a440a94c7fc0b12b755a838cc3f9b8245d9f926e0432d07ee97557cff7c50c73f64a58",
     signBytes:
@@ -50,7 +50,7 @@ const testVectors = [
   },
 
   {
-    sequenceNumber: 2,
+    sequence: 2,
     signedTxBytes:
       "0a580a560a142f636f736d6f732e62616e6b2e4d736753656e64123e0a140d82b1e7c96dbfa42462fe612932e6bff111d51b12140102030405060708090a0b0c0d0e0f10111213141a100a0575636f736d12073132333435363712330a2b0a230a21034f04181eeba35391b858633a765c4a0c189697b40d216354d50890d350c7029012040a020801120410c09a0c1a405e2e11567c181db4f38788ff6d417b1f7d147f3d6bd8274989bf181c35b3fb97218f64172030dd5a84dd38933765609d70771cbba60168d8ded611f14ec4fb12",
     signBytes:
@@ -148,7 +148,7 @@ describe("signing demo", () => {
     const accountNumber = 1;
 
     await Promise.all(
-      testVectors.map(async ({ sequenceNumber: sequence, signBytes, signedTxBytes }) => {
+      testVectors.map(async ({ sequence, signBytes, signedTxBytes }) => {
         const signDocBytes = makeSignBytes(txBodyBytes, authInfoBytes, chainId, accountNumber, sequence);
         expect(toHex(signDocBytes)).toEqual(signBytes);
 

--- a/packages/proto-signing/src/signing.spec.ts
+++ b/packages/proto-signing/src/signing.spec.ts
@@ -2,13 +2,12 @@
 import { Bech32, fromBase64, fromHex, toHex } from "@cosmjs/encoding";
 import { Secp256k1Wallet } from "@cosmjs/launchpad";
 
-import { omitDefaults } from "./adr27";
 import { cosmos } from "./generated/codecimpl";
 import { defaultRegistry } from "./msgs";
 import { Registry, TxBodyValue } from "./registry";
 import { makeSignBytes } from "./signing";
 
-const { AuthInfo, SignDoc, Tx, TxBody } = cosmos.tx;
+const { AuthInfo, Tx, TxBody } = cosmos.tx;
 const { PublicKey } = cosmos.crypto;
 
 export function pendingWithoutSimapp(): void {
@@ -149,17 +148,8 @@ describe("signing demo", () => {
     const accountNumber = 1;
 
     await Promise.all(
-      testVectors.map(async ({ sequenceNumber, signBytes, signedTxBytes }) => {
-        const signDoc = SignDoc.create(
-          omitDefaults({
-            bodyBytes: txBodyBytes,
-            authInfoBytes: authInfoBytes,
-            chainId: chainId,
-            accountNumber: accountNumber,
-            accountSequence: sequenceNumber,
-          }),
-        );
-        const signDocBytes = makeSignBytes(signDoc);
+      testVectors.map(async ({ sequenceNumber: sequence, signBytes, signedTxBytes }) => {
+        const signDocBytes = makeSignBytes(txBodyBytes, authInfoBytes, chainId, accountNumber, sequence);
         expect(toHex(signDocBytes)).toEqual(signBytes);
 
         const signature = await wallet.sign(address, signDocBytes);

--- a/packages/proto-signing/src/signing.ts
+++ b/packages/proto-signing/src/signing.ts
@@ -1,8 +1,24 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { omitDefaults } from "./adr27";
 import { cosmos } from "./generated/codecimpl";
 
 const { SignDoc } = cosmos.tx;
 
-export function makeSignBytes(signDoc: cosmos.tx.ISignDoc): Uint8Array {
+export function makeSignBytes(
+  txBody: Uint8Array,
+  authInfo: Uint8Array,
+  chainId: string,
+  accountNumber: number,
+  sequence: number,
+): Uint8Array {
+  const signDoc = SignDoc.create(
+    omitDefaults({
+      bodyBytes: txBody,
+      authInfoBytes: authInfo,
+      chainId: chainId,
+      accountNumber: accountNumber,
+      accountSequence: sequence,
+    }),
+  );
   return Uint8Array.from(SignDoc.encode(signDoc).finish());
 }

--- a/packages/proto-signing/types/index.d.ts
+++ b/packages/proto-signing/types/index.d.ts
@@ -1,4 +1,3 @@
-export { omitDefaults } from "./adr27";
 export { Coin } from "./msgs";
 export { cosmosField } from "./decorator";
 export { Registry } from "./registry";

--- a/packages/proto-signing/types/signing.d.ts
+++ b/packages/proto-signing/types/signing.d.ts
@@ -1,2 +1,7 @@
-import { cosmos } from "./generated/codecimpl";
-export declare function makeSignBytes(signDoc: cosmos.tx.ISignDoc): Uint8Array;
+export declare function makeSignBytes(
+  txBody: Uint8Array,
+  authInfo: Uint8Array,
+  chainId: string,
+  accountNumber: number,
+  sequence: number,
+): Uint8Array;

--- a/packages/stargate/src/stargateclient.searchtx.spec.ts
+++ b/packages/stargate/src/stargateclient.searchtx.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Bech32, fromBase64 } from "@cosmjs/encoding";
 import { Coin, coins, Secp256k1Wallet } from "@cosmjs/launchpad";
-import { makeSignBytes, omitDefaults, Registry } from "@cosmjs/proto-signing";
+import { makeSignBytes, Registry } from "@cosmjs/proto-signing";
 import { assert } from "@cosmjs/utils";
 import Long from "long";
 
@@ -14,7 +14,7 @@ import {
 } from "./stargateclient";
 import { faucet, makeRandomAddress, pendingWithoutSimapp, simapp, simappEnabled } from "./testutils.spec";
 
-const { AuthInfo, SignDoc, Tx, TxBody } = cosmos.tx;
+const { AuthInfo, Tx, TxBody } = cosmos.tx;
 const { PublicKey } = cosmos.crypto;
 
 interface TestTxSend {
@@ -76,16 +76,7 @@ async function sendTokens(
 
   const { accountNumber, sequence } = (await client.getSequence(walletAddress))!;
   const chainId = await client.getChainId();
-  const signDoc = SignDoc.create(
-    omitDefaults({
-      bodyBytes: txBodyBytes,
-      authInfoBytes: authInfoBytes,
-      chainId: chainId,
-      accountNumber: accountNumber,
-      accountSequence: sequence,
-    }),
-  );
-  const signDocBytes = makeSignBytes(signDoc);
+  const signDocBytes = makeSignBytes(txBodyBytes, authInfoBytes, chainId, accountNumber, sequence);
   const signature = await wallet.sign(walletAddress, signDocBytes);
   const txRaw = Tx.create({
     body: txBody,

--- a/packages/stargate/src/stargateclient.spec.ts
+++ b/packages/stargate/src/stargateclient.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Bech32, fromBase64 } from "@cosmjs/encoding";
 import { Secp256k1Wallet } from "@cosmjs/launchpad";
-import { makeSignBytes, omitDefaults, Registry } from "@cosmjs/proto-signing";
+import { makeSignBytes, Registry } from "@cosmjs/proto-signing";
 import { assert, sleep } from "@cosmjs/utils";
 import Long from "long";
 import { ReadonlyDate } from "readonly-date";
@@ -19,7 +19,7 @@ import {
   validator,
 } from "./testutils.spec";
 
-const { AuthInfo, SignDoc, Tx, TxBody } = cosmos.tx;
+const { AuthInfo, Tx, TxBody } = cosmos.tx;
 const { PublicKey } = cosmos.crypto;
 
 describe("StargateClient", () => {
@@ -298,16 +298,7 @@ describe("StargateClient", () => {
 
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = (await client.getSequence(address))!;
-      const signDoc = SignDoc.create(
-        omitDefaults({
-          bodyBytes: txBodyBytes,
-          authInfoBytes: authInfoBytes,
-          chainId: chainId,
-          accountNumber: accountNumber,
-          accountSequence: sequence,
-        }),
-      );
-      const signDocBytes = makeSignBytes(signDoc);
+      const signDocBytes = makeSignBytes(txBodyBytes, authInfoBytes, chainId, accountNumber, sequence);
       const signature = await wallet.sign(address, signDocBytes);
       const txRaw = Tx.create({
         body: txBody,


### PR DESCRIPTION
This is only the first step of an effort of keeping all types for signing in @cosmjs/proto-signing.