### PR TITLE
Verify ics23 proofs

### DIFF
--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -46,13 +46,13 @@
   },
   "dependencies": {
     "@confio/ics23": "^0.6.0",
-    "@cosmjs/encoding": "^0.22.2",
-    "@cosmjs/launchpad": "^0.22.2",
-    "@cosmjs/math": "^0.22.2",
-    "@cosmjs/proto-signing": "^0.22.2",
-    "@cosmjs/stream": "^0.22.2",
-    "@cosmjs/tendermint-rpc": "^0.22.2",
-    "@cosmjs/utils": "^0.22.2",
+    "@cosmjs/encoding": "^0.22.1",
+    "@cosmjs/launchpad": "^0.22.1",
+    "@cosmjs/math": "^0.22.1",
+    "@cosmjs/proto-signing": "^0.22.1",
+    "@cosmjs/stream": "^0.22.1",
+    "@cosmjs/tendermint-rpc": "^0.22.1",
+    "@cosmjs/utils": "^0.22.1",
     "protobufjs": "~6.10.0"
   }
 }

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -46,13 +46,13 @@
   },
   "dependencies": {
     "@confio/ics23": "^0.6.3",
-    "@cosmjs/encoding": "^0.22.1",
-    "@cosmjs/launchpad": "^0.22.1",
-    "@cosmjs/math": "^0.22.1",
-    "@cosmjs/proto-signing": "^0.22.1",
-    "@cosmjs/stream": "^0.22.1",
-    "@cosmjs/tendermint-rpc": "^0.22.1",
-    "@cosmjs/utils": "^0.22.1",
+    "@cosmjs/encoding": "^0.22.2",
+    "@cosmjs/launchpad": "^0.22.2",
+    "@cosmjs/math": "^0.22.2",
+    "@cosmjs/proto-signing": "^0.22.2",
+    "@cosmjs/stream": "^0.22.2",
+    "@cosmjs/tendermint-rpc": "^0.22.2",
+    "@cosmjs/utils": "^0.22.2",
     "protobufjs": "~6.10.0"
   }
 }

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -45,6 +45,7 @@
     "postdefine-proto": "prettier --write \"src/codec/generated/codecimpl.*\""
   },
   "dependencies": {
+    "@confio/ics23": "^0.6.0",
     "@cosmjs/encoding": "^0.22.2",
     "@cosmjs/launchpad": "^0.22.2",
     "@cosmjs/math": "^0.22.2",

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -45,7 +45,7 @@
     "postdefine-proto": "prettier --write \"src/codec/generated/codecimpl.*\""
   },
   "dependencies": {
-    "@confio/ics23": "^0.6.0",
+    "@confio/ics23": "^0.6.3",
     "@cosmjs/encoding": "^0.22.1",
     "@cosmjs/launchpad": "^0.22.1",
     "@cosmjs/math": "^0.22.1",

--- a/packages/stargate/package.json
+++ b/packages/stargate/package.json
@@ -50,6 +50,7 @@
     "@cosmjs/launchpad": "^0.22.2",
     "@cosmjs/math": "^0.22.2",
     "@cosmjs/proto-signing": "^0.22.2",
+    "@cosmjs/stream": "^0.22.2",
     "@cosmjs/tendermint-rpc": "^0.22.2",
     "@cosmjs/utils": "^0.22.2",
     "protobufjs": "~6.10.0"

--- a/packages/stargate/src/queries/queryclient.ts
+++ b/packages/stargate/src/queries/queryclient.ts
@@ -227,8 +227,12 @@ export class QueryClient {
     if (height == 0) {
       throw new Error("Query returned height 0, cannot prove it");
     }
-    // get the header for height+1
+
+    // get the header for height+1 with events
     const header = await firstEvent(this.tmClient.subscribeNewBlockHeader());
+    // alternate non-websocket query (fails with error as it is the future)
+    // const header = (await this.tmClient.blockchain(height+1, height+1)).blockMetas[0].header;
+
     if (header.height !== height + 1) {
       throw new Error(`Query returned height ${height}, but next header was ${header.height}`);
     }

--- a/packages/stargate/src/queries/queryclient.ts
+++ b/packages/stargate/src/queries/queryclient.ts
@@ -1,44 +1,9 @@
 /* eslint-disable no-dupe-class-members, @typescript-eslint/ban-types, @typescript-eslint/naming-convention */
-import { ics23, verifyExistence, verifyNonExistence } from "@confio/ics23";
+import { iavlSpec, ics23, tendermintSpec, verifyExistence, verifyNonExistence } from "@confio/ics23";
 import { fromAscii, toAscii, toHex } from "@cosmjs/encoding";
 import { firstEvent } from "@cosmjs/stream";
 import { Client as TendermintClient } from "@cosmjs/tendermint-rpc";
 import { arrayContentEquals, assert, isNonNullObject } from "@cosmjs/utils";
-
-// TODO: import these from @confio/ics23 when exported
-export const IavlSpec: ics23.IProofSpec = {
-  leafSpec: {
-    prefix: Uint8Array.from([0]),
-    hash: ics23.HashOp.SHA256,
-    prehashValue: ics23.HashOp.SHA256,
-    prehashKey: ics23.HashOp.NO_HASH,
-    length: ics23.LengthOp.VAR_PROTO,
-  },
-  innerSpec: {
-    childOrder: [0, 1],
-    minPrefixLength: 4,
-    maxPrefixLength: 12,
-    childSize: 33,
-    hash: ics23.HashOp.SHA256,
-  },
-};
-
-export const TendermintSpec: ics23.IProofSpec = {
-  leafSpec: {
-    prefix: Uint8Array.from([0]),
-    hash: ics23.HashOp.SHA256,
-    prehashValue: ics23.HashOp.SHA256,
-    prehashKey: ics23.HashOp.NO_HASH,
-    length: ics23.LengthOp.VAR_PROTO,
-  },
-  innerSpec: {
-    childOrder: [0, 1],
-    minPrefixLength: 1,
-    maxPrefixLength: 1,
-    childSize: 32,
-    hash: ics23.HashOp.SHA256,
-  },
-};
 
 type QueryExtensionSetup<P> = (base: QueryClient) => P;
 
@@ -233,13 +198,13 @@ export class QueryClient {
       // non-existence check
       assert(subProof.nonexist);
       // the subproof must map the desired key to the "value" of the storeProof
-      verifyNonExistence(subProof.nonexist, IavlSpec, storeProof.exist.value, key);
+      verifyNonExistence(subProof.nonexist, iavlSpec, storeProof.exist.value, key);
     } else {
       // existence check
       assert(subProof.exist);
       assert(subProof.exist.value);
       // the subproof must map the desired key to the "value" of the storeProof
-      verifyExistence(subProof.exist, IavlSpec, storeProof.exist.value, key, response.value);
+      verifyExistence(subProof.exist, iavlSpec, storeProof.exist.value, key, response.value);
     }
 
     // the storeproof must map it's declared value (root of subProof) to the appHash of the next block
@@ -253,7 +218,7 @@ export class QueryClient {
       throw new Error(`Query returned height ${response.height}, but next header was ${header.height}`);
     }
 
-    verifyExistence(storeProof.exist, TendermintSpec, header.appHash, toAscii(store), storeProof.exist.value);
+    verifyExistence(storeProof.exist, tendermintSpec, header.appHash, toAscii(store), storeProof.exist.value);
 
     return response.value;
   }

--- a/packages/stargate/src/queries/queryclient.ts
+++ b/packages/stargate/src/queries/queryclient.ts
@@ -161,6 +161,8 @@ export class QueryClient {
       throw new Error(`Response key ${toHex(response.key)} doesn't match query key ${toHex(key)}`);
     }
 
+    assert(response.proof);
+
     // TODO: implement proof verification
     // https://github.com/CosmWasm/cosmjs/issues/347
 

--- a/packages/stargate/types/queries/queryclient.d.ts
+++ b/packages/stargate/types/queries/queryclient.d.ts
@@ -1,3 +1,4 @@
+import { ics23 } from "@confio/ics23";
 import { Client as TendermintClient } from "@cosmjs/tendermint-rpc";
 declare type QueryExtensionSetup<P> = (base: QueryClient) => P;
 export declare class QueryClient {
@@ -106,4 +107,6 @@ export declare class QueryClient {
   queryVerified(store: string, key: Uint8Array): Promise<Uint8Array>;
   queryUnverified(path: string, request: Uint8Array): Promise<Uint8Array>;
 }
+export declare const IavlSpec: ics23.IProofSpec;
+export declare const TendermintSpec: ics23.IProofSpec;
 export {};

--- a/packages/stargate/types/queries/queryclient.d.ts
+++ b/packages/stargate/types/queries/queryclient.d.ts
@@ -1,5 +1,7 @@
 import { ics23 } from "@confio/ics23";
 import { Client as TendermintClient } from "@cosmjs/tendermint-rpc";
+export declare const IavlSpec: ics23.IProofSpec;
+export declare const TendermintSpec: ics23.IProofSpec;
 declare type QueryExtensionSetup<P> = (base: QueryClient) => P;
 export declare class QueryClient {
   /** Constructs a QueryClient with 0 extensions */
@@ -107,6 +109,4 @@ export declare class QueryClient {
   queryVerified(store: string, key: Uint8Array): Promise<Uint8Array>;
   queryUnverified(path: string, request: Uint8Array): Promise<Uint8Array>;
 }
-export declare const IavlSpec: ics23.IProofSpec;
-export declare const TendermintSpec: ics23.IProofSpec;
 export {};

--- a/packages/stargate/types/queries/queryclient.d.ts
+++ b/packages/stargate/types/queries/queryclient.d.ts
@@ -105,5 +105,6 @@ export declare class QueryClient {
   constructor(tmClient: TendermintClient);
   queryVerified(store: string, key: Uint8Array): Promise<Uint8Array>;
   queryUnverified(path: string, request: Uint8Array): Promise<Uint8Array>;
+  private getNextHeader;
 }
 export {};

--- a/packages/stargate/types/queries/queryclient.d.ts
+++ b/packages/stargate/types/queries/queryclient.d.ts
@@ -1,7 +1,4 @@
-import { ics23 } from "@confio/ics23";
 import { Client as TendermintClient } from "@cosmjs/tendermint-rpc";
-export declare const IavlSpec: ics23.IProofSpec;
-export declare const TendermintSpec: ics23.IProofSpec;
 declare type QueryExtensionSetup<P> = (base: QueryClient) => P;
 export declare class QueryClient {
   /** Constructs a QueryClient with 0 extensions */

--- a/packages/tendermint-rpc/src/responses.ts
+++ b/packages/tendermint-rpc/src/responses.ts
@@ -25,9 +25,20 @@ export interface AbciInfoResponse {
   readonly lastBlockAppHash?: Uint8Array;
 }
 
+export interface ProofOp {
+  readonly type: string;
+  readonly key: Uint8Array;
+  readonly data: Uint8Array;
+}
+
+export interface QueryProof {
+  readonly ops: readonly ProofOp[];
+}
+
 export interface AbciQueryResponse {
   readonly key: Uint8Array;
   readonly value: Uint8Array;
+  readonly proof?: QueryProof;
   readonly height?: number;
   readonly index?: number;
   readonly code?: number; // non-falsy for errors

--- a/packages/tendermint-rpc/src/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/v0-33/responses.ts
@@ -25,6 +25,7 @@ import * as responses from "../responses";
 import { SubscriptionEvent } from "../rpcclients";
 import { IpPortString, TxBytes, TxHash, ValidatorPubkey, ValidatorSignature } from "../types";
 import { hashTx } from "./hasher";
+import { isArgon2idOptions } from "@cosmjs/crypto";
 
 interface AbciInfoResult {
   readonly response: RpcAbciInfoResponse;
@@ -48,10 +49,30 @@ interface AbciQueryResult {
   readonly response: RpcAbciQueryResponse;
 }
 
+export interface RpcProofOp {
+  readonly type: string;
+  readonly key: Base64String;
+  readonly data: Base64String;
+}
+
+export interface RpcQueryProof {
+  readonly ops: readonly RpcProofOp[];
+}
+
+function decodeQueryProof(data: RpcQueryProof): responses.QueryProof {
+  return {
+    ops: data.ops.map((op) => ({
+      type: op.type,
+      key: Base64.decode(op.key),
+      data: Base64.decode(op.data),
+    })),
+  };
+}
+
 interface RpcAbciQueryResponse {
   readonly key: Base64String;
   readonly value?: Base64String;
-  readonly proof?: Base64String;
+  readonly proof?: RpcQueryProof;
   readonly height?: IntegerString;
   readonly index?: IntegerString;
   readonly code?: IntegerString; // only for errors
@@ -62,7 +83,7 @@ function decodeAbciQuery(data: RpcAbciQueryResponse): responses.AbciQueryRespons
   return {
     key: Base64.decode(optional(data.key, "" as Base64String)),
     value: Base64.decode(optional(data.value, "" as Base64String)),
-    // proof: may(Base64.decode, data.proof),
+    proof: may(decodeQueryProof, data.proof),
     height: may(Integer.parse, data.height),
     code: may(Integer.parse, data.code),
     index: may(Integer.parse, data.index),

--- a/packages/tendermint-rpc/src/v0-33/responses.ts
+++ b/packages/tendermint-rpc/src/v0-33/responses.ts
@@ -25,7 +25,6 @@ import * as responses from "../responses";
 import { SubscriptionEvent } from "../rpcclients";
 import { IpPortString, TxBytes, TxHash, ValidatorPubkey, ValidatorSignature } from "../types";
 import { hashTx } from "./hasher";
-import { isArgon2idOptions } from "@cosmjs/crypto";
 
 interface AbciInfoResult {
   readonly response: RpcAbciInfoResponse;

--- a/packages/tendermint-rpc/types/responses.d.ts
+++ b/packages/tendermint-rpc/types/responses.d.ts
@@ -21,9 +21,18 @@ export interface AbciInfoResponse {
   readonly lastBlockHeight?: number;
   readonly lastBlockAppHash?: Uint8Array;
 }
+export interface ProofOp {
+  readonly type: string;
+  readonly key: Uint8Array;
+  readonly data: Uint8Array;
+}
+export interface QueryProof {
+  readonly ops: readonly ProofOp[];
+}
 export interface AbciQueryResponse {
   readonly key: Uint8Array;
   readonly value: Uint8Array;
+  readonly proof?: QueryProof;
   readonly height?: number;
   readonly index?: number;
   readonly code?: number;

--- a/packages/tendermint-rpc/types/v0-33/responses.d.ts
+++ b/packages/tendermint-rpc/types/v0-33/responses.d.ts
@@ -1,6 +1,15 @@
 import { JsonRpcSuccessResponse } from "@cosmjs/json-rpc";
+import { Base64String } from "../encodings";
 import * as responses from "../responses";
 import { SubscriptionEvent } from "../rpcclients";
+export interface RpcProofOp {
+  readonly type: string;
+  readonly key: Base64String;
+  readonly data: Base64String;
+}
+export interface RpcQueryProof {
+  readonly ops: readonly RpcProofOp[];
+}
 export declare class Responses {
   static decodeAbciInfo(response: JsonRpcSuccessResponse): responses.AbciInfoResponse;
   static decodeAbciQuery(response: JsonRpcSuccessResponse): responses.AbciQueryResponse;

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,21 +177,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@confio/ics23@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@confio/ics23/-/ics23-0.6.0.tgz#8c3e6508159bdbee02b12beeee9b369ea68ef6ba"
-  integrity sha512-P/NcAO3pz7xXg4cpwaKRUIN4PuOOxwY94n7WD+wod7UG5YlMLzb8Upv6nZo9/brnKXW4gXB2DccLTtV0Um1Wvw==
+"@confio/ics23@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@confio/ics23/-/ics23-0.6.3.tgz#d27da1efca21253dee1b7d038913d72a99a17ca1"
+  integrity sha512-SQDH9tTzXIbC1AVTrjL7BEXfsYwERXNOB7F995LhfJDrP44cC5sl3Prh+lkfKOjn1jkgxknVUyaGx3tMG88gjQ==
   dependencies:
     protobufjs "^6.8.8"
     ripemd160 "^2.0.2"
     sha.js "^2.4.11"
-
-"@cosmjs/stream@^0.22.2":
-  version "0.22.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/stream/-/stream-0.22.2.tgz#060c00374d06586a23b53f1f3a7f0bd4aa98557d"
-  integrity sha512-X3EG8HNn3nW+2iXjff6r8a77crermJ/aSijLxzw1in9+hipF6hG4UmSxN14knSPF6lfqSp80oFoKR6GT1/2r5w==
-  dependencies:
-    xstream "^11.10.0"
 
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6773,29 +6773,10 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-protobufjs@^6.8.8:
+protobufjs@^6.8.8, protobufjs@~6.10.0:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.1.tgz#e6a484dd8f04b29629e9053344e3970cccf13cd2"
   integrity sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
-    "@types/node" "^13.7.0"
-    long "^4.0.0"
-
-protobufjs@~6.10.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.0.tgz#b0698a2a91fc597e2dc625dcf3539ece9675c8fd"
-  integrity sha512-Hdz1+CXkrlmGDKkP6DczxysdnUyUuhM1mjeaydnBxOcjxQPbJldLZ8eGE1gX0UTsgv+0QkFfn6dioo5yt9XORw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,6 +177,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@confio/ics23@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@confio/ics23/-/ics23-0.6.0.tgz#8c3e6508159bdbee02b12beeee9b369ea68ef6ba"
+  integrity sha512-P/NcAO3pz7xXg4cpwaKRUIN4PuOOxwY94n7WD+wod7UG5YlMLzb8Upv6nZo9/brnKXW4gXB2DccLTtV0Um1Wvw==
+  dependencies:
+    protobufjs "^6.8.8"
+    ripemd160 "^2.0.2"
+    sha.js "^2.4.11"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -6763,6 +6772,25 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protobufjs@^6.8.8:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.1.tgz#e6a484dd8f04b29629e9053344e3970cccf13cd2"
+  integrity sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" "^13.7.0"
+    long "^4.0.0"
 
 protobufjs@~6.10.0:
   version "6.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -186,6 +186,13 @@
     ripemd160 "^2.0.2"
     sha.js "^2.4.11"
 
+"@cosmjs/stream@^0.22.2":
+  version "0.22.2"
+  resolved "https://registry.yarnpkg.com/@cosmjs/stream/-/stream-0.22.2.tgz#060c00374d06586a23b53f1f3a7f0bd4aa98557d"
+  integrity sha512-X3EG8HNn3nW+2iXjff6r8a77crermJ/aSijLxzw1in9+hipF6hG4UmSxN14knSPF6lfqSp80oFoKR6GT1/2r5w==
+  dependencies:
+    xstream "^11.10.0"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"


### PR DESCRIPTION
Closes #347 

- [x] Parses proof info in tendermint rpc
- [x] Validate proper sdk proof format in `queryVerified`
- [x] Validate the ics23 proof itself