### PR TITLE
Test QueryClient directly

### DIFF
--- a/packages/stargate/src/queries/auth.spec.ts
+++ b/packages/stargate/src/queries/auth.spec.ts
@@ -8,7 +8,7 @@ import { AuthExtension, setupAuthExtension } from "./auth";
 import { QueryClient } from "./queryclient";
 import { toAccAddress } from "./utils";
 
-async function makeAuthClient(rpcUrl: string): Promise<[QueryClient & AuthExtension, TendermintClient]> {
+async function makeClientWithAuth(rpcUrl: string): Promise<[QueryClient & AuthExtension, TendermintClient]> {
   const tmClient = await TendermintClient.connect(rpcUrl);
   return [QueryClient.withExtensions(tmClient, setupAuthExtension), tmClient];
 }
@@ -17,7 +17,7 @@ describe("AuthExtension", () => {
   describe("account", () => {
     it("works for unused account", async () => {
       pendingWithoutSimapp();
-      const [client, tmClient] = await makeAuthClient(simapp.tendermintUrl);
+      const [client, tmClient] = await makeClientWithAuth(simapp.tendermintUrl);
 
       const account = await client.auth.account(unused.address);
       assert(account);
@@ -34,7 +34,7 @@ describe("AuthExtension", () => {
 
     it("works for account with pubkey and non-zero sequence", async () => {
       pendingWithoutSimapp();
-      const [client, tmClient] = await makeAuthClient(simapp.tendermintUrl);
+      const [client, tmClient] = await makeClientWithAuth(simapp.tendermintUrl);
 
       const account = await client.auth.account(validator.address);
       assert(account);
@@ -50,7 +50,7 @@ describe("AuthExtension", () => {
 
     it("returns null for non-existent address", async () => {
       pendingWithoutSimapp();
-      const [client, tmClient] = await makeAuthClient(simapp.tendermintUrl);
+      const [client, tmClient] = await makeClientWithAuth(simapp.tendermintUrl);
 
       const account = await client.auth.account(nonExistentAddress);
       expect(account).toBeNull();
@@ -63,7 +63,7 @@ describe("AuthExtension", () => {
     describe("account", () => {
       it("works for unused account", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeAuthClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithAuth(simapp.tendermintUrl);
 
         const account = await client.auth.unverified.account(unused.address);
         assert(account);
@@ -79,7 +79,7 @@ describe("AuthExtension", () => {
 
       it("works for account with pubkey and non-zero sequence", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeAuthClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithAuth(simapp.tendermintUrl);
 
         const account = await client.auth.unverified.account(validator.address);
         assert(account);
@@ -96,7 +96,7 @@ describe("AuthExtension", () => {
       it("returns null for non-existent address", async () => {
         pending("This fails with Error: Query failed with (1): internal");
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeAuthClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithAuth(simapp.tendermintUrl);
 
         const account = await client.auth.unverified.account(nonExistentAddress);
         expect(account).toBeNull();

--- a/packages/stargate/src/queries/bank.spec.ts
+++ b/packages/stargate/src/queries/bank.spec.ts
@@ -10,7 +10,7 @@ import {
 import { BankExtension, setupBankExtension } from "./bank";
 import { QueryClient } from "./queryclient";
 
-async function makeBankClient(rpcUrl: string): Promise<[QueryClient & BankExtension, TendermintClient]> {
+async function makeClientWithBank(rpcUrl: string): Promise<[QueryClient & BankExtension, TendermintClient]> {
   const tmClient = await TendermintClient.connect(rpcUrl);
   return [QueryClient.withExtensions(tmClient, setupBankExtension), tmClient];
 }
@@ -19,7 +19,7 @@ describe("BankExtension", () => {
   describe("balance", () => {
     it("works for different existing balances", async () => {
       pendingWithoutSimapp();
-      const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+      const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
       const response1 = await client.bank.balance(unused.address, simapp.denomFee);
       expect(response1).toEqual({
@@ -37,7 +37,7 @@ describe("BankExtension", () => {
 
     it("returns null for non-existent balance", async () => {
       pendingWithoutSimapp();
-      const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+      const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
       const response = await client.bank.balance(unused.address, "gintonic");
       expect(response).toBeNull();
@@ -47,7 +47,7 @@ describe("BankExtension", () => {
 
     it("returns null for non-existent address", async () => {
       pendingWithoutSimapp();
-      const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+      const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
       const response = await client.bank.balance(nonExistentAddress, simapp.denomFee);
       expect(response).toBeNull();
@@ -60,7 +60,7 @@ describe("BankExtension", () => {
     describe("balance", () => {
       it("works for different existing balances", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const response1 = await client.bank.unverified.balance(unused.address, simapp.denomFee);
         expect(response1).toEqual({
@@ -78,7 +78,7 @@ describe("BankExtension", () => {
 
       it("returns zero for non-existent balance", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const response = await client.bank.unverified.balance(unused.address, "gintonic");
         expect(response).toEqual({
@@ -91,7 +91,7 @@ describe("BankExtension", () => {
 
       it("returns zero for non-existent address", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const response = await client.bank.unverified.balance(nonExistentAddress, simapp.denomFee);
         expect(response).toEqual({
@@ -106,7 +106,7 @@ describe("BankExtension", () => {
     describe("allBalances", () => {
       it("returns all balances for unused account", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const balances = await client.bank.unverified.allBalances(unused.address);
         expect(balances).toEqual([
@@ -125,7 +125,7 @@ describe("BankExtension", () => {
 
       it("returns an empty list for non-existent account", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const balances = await client.bank.unverified.allBalances(nonExistentAddress);
         expect(balances).toEqual([]);
@@ -137,7 +137,7 @@ describe("BankExtension", () => {
     describe("totalSupply", () => {
       it("works", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const response = await client.bank.unverified.totalSupply();
         expect(response).toEqual([
@@ -158,7 +158,7 @@ describe("BankExtension", () => {
     describe("supplyOf", () => {
       it("works for existing denom", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const response = await client.bank.unverified.supplyOf(simapp.denomFee);
         expect(response).toEqual({
@@ -171,7 +171,7 @@ describe("BankExtension", () => {
 
       it("returns zero for non-existent denom", async () => {
         pendingWithoutSimapp();
-        const [client, tmClient] = await makeBankClient(simapp.tendermintUrl);
+        const [client, tmClient] = await makeClientWithBank(simapp.tendermintUrl);
 
         const response = await client.bank.unverified.supplyOf("gintonic");
         expect(response).toEqual({

--- a/packages/stargate/src/queries/queryclient.spec.ts
+++ b/packages/stargate/src/queries/queryclient.spec.ts
@@ -1,0 +1,80 @@
+import { toAscii } from "@cosmjs/encoding";
+import { Client as TendermintClient } from "@cosmjs/tendermint-rpc";
+
+import { cosmos } from "../codec";
+import { nonNegativeIntegerMatcher, pendingWithoutSimapp, simapp, unused } from "../testutils.spec";
+import { QueryClient } from "./queryclient";
+import { toAccAddress } from "./utils";
+
+async function makeClient(rpcUrl: string): Promise<[QueryClient, TendermintClient]> {
+  const tmClient = await TendermintClient.connect(rpcUrl);
+  return [QueryClient.withExtensions(tmClient), tmClient];
+}
+
+describe("QueryClient", () => {
+  describe("queryVerified", () => {
+    it("works via WebSockets", async () => {
+      pendingWithoutSimapp();
+      const [client, tmClient] = await makeClient(simapp.tendermintUrlWs);
+
+      const key = Uint8Array.from([
+        ...toAscii("balances"),
+        ...toAccAddress(unused.address),
+        ...toAscii(simapp.denomFee),
+      ]);
+      const data = await client.queryVerified("bank", key);
+      const response = cosmos.Coin.decode(data);
+      expect(response.amount).toMatch(nonNegativeIntegerMatcher);
+      expect(response.denom).toEqual(simapp.denomFee);
+
+      tmClient.disconnect();
+    });
+
+    it("works via http", async () => {
+      pendingWithoutSimapp();
+      const [client, tmClient] = await makeClient(simapp.tendermintUrlHttp);
+
+      const key = Uint8Array.from([
+        ...toAscii("balances"),
+        ...toAccAddress(unused.address),
+        ...toAscii(simapp.denomFee),
+      ]);
+      const data = await client.queryVerified("bank", key);
+      const response = cosmos.Coin.decode(data);
+      expect(response.amount).toMatch(nonNegativeIntegerMatcher);
+      expect(response.denom).toEqual(simapp.denomFee);
+
+      tmClient.disconnect();
+    });
+  });
+
+  describe("queryUnverified", () => {
+    it("works via WebSockets", async () => {
+      pendingWithoutSimapp();
+      const [client, tmClient] = await makeClient(simapp.tendermintUrlWs);
+
+      const requestData = Uint8Array.from(
+        cosmos.bank.QueryAllBalancesRequest.encode({ address: toAccAddress(unused.address) }).finish(),
+      );
+      const data = await client.queryUnverified(`/cosmos.bank.Query/AllBalances`, requestData);
+      const response = cosmos.bank.QueryAllBalancesResponse.decode(data);
+      expect(response.balances.length).toEqual(2);
+
+      tmClient.disconnect();
+    });
+
+    it("works via http", async () => {
+      pendingWithoutSimapp();
+      const [client, tmClient] = await makeClient(simapp.tendermintUrlHttp);
+
+      const requestData = Uint8Array.from(
+        cosmos.bank.QueryAllBalancesRequest.encode({ address: toAccAddress(unused.address) }).finish(),
+      );
+      const data = await client.queryUnverified(`/cosmos.bank.Query/AllBalances`, requestData);
+      const response = cosmos.bank.QueryAllBalancesResponse.decode(data);
+      expect(response.balances.length).toEqual(2);
+
+      tmClient.disconnect();
+    });
+  });
+});

--- a/packages/stargate/src/testutils.spec.ts
+++ b/packages/stargate/src/testutils.spec.ts
@@ -21,6 +21,8 @@ export function makeRandomAddress(): string {
 
 export const simapp = {
   tendermintUrl: "localhost:26657",
+  tendermintUrlWs: "ws://localhost:26657",
+  tendermintUrlHttp: "http://localhost:26657",
   chainId: "simd-testing",
   denomStaking: "ustake",
   denomFee: "ucosm",

--- a/scripts/simapp/generate_template.sh
+++ b/scripts/simapp/generate_template.sh
@@ -52,7 +52,7 @@ function inline_jq() {
 
   # Custom settings in config.toml
   sed -i "" \
-    -e 's/^cors_allowed_origins.*$/cors_allowed_origins = ["*"]/' \
+    -e 's/^cors_allowed_origins =.*$/cors_allowed_origins = ["*"]/' \
     -e 's/^timeout_propose =.*$/timeout_propose = "300ms"/' \
     -e 's/^timeout_propose_delta =.*$/timeout_propose_delta = "100ms"/' \
     -e 's/^timeout_prevote =.*$/timeout_prevote = "300ms"/' \

--- a/scripts/simapp/generate_template.sh
+++ b/scripts/simapp/generate_template.sh
@@ -52,6 +52,7 @@ function inline_jq() {
 
   # Custom settings in config.toml
   sed -i "" \
+    -e 's/^cors_allowed_origins.*$/cors_allowed_origins = ["*"]/' \
     -e 's/^timeout_propose =.*$/timeout_propose = "300ms"/' \
     -e 's/^timeout_propose_delta =.*$/timeout_propose_delta = "100ms"/' \
     -e 's/^timeout_prevote =.*$/timeout_prevote = "300ms"/' \

--- a/scripts/simapp/template/.simapp/config/config.toml
+++ b/scripts/simapp/template/.simapp/config/config.toml
@@ -86,7 +86,7 @@ laddr = "tcp://127.0.0.1:26657"
 # A list of origins a cross-domain request can be executed from
 # Default value '[]' disables cors support
 # Use '["*"]' to allow any origin
-cors_allowed_origins = []
+cors_allowed_origins = ["*"]
 
 # A list of methods the client is allowed to use with cross-domain requests
 cors_allowed_methods = ["HEAD", "GET", "POST", ]

--- a/scripts/tendermint/start.sh
+++ b/scripts/tendermint/start.sh
@@ -26,7 +26,7 @@ docker run --rm \
 
 # make sure we allow cors origins, only possible by modifying the config file
 # https://github.com/tendermint/tendermint/issues/3216
-sed -ie 's/^cors_allowed_origins.*$/cors_allowed_origins = ["*"]/' "${TMP_DIR}/config/config.toml"
+sed -ie 's/^cors_allowed_origins =.*$/cors_allowed_origins = ["*"]/' "${TMP_DIR}/config/config.toml"
 
 # must enable tx index for search and subscribe
 docker run --rm \

--- a/scripts/tendermint/start.sh
+++ b/scripts/tendermint/start.sh
@@ -26,7 +26,7 @@ docker run --rm \
 
 # make sure we allow cors origins, only possible by modifying the config file
 # https://github.com/tendermint/tendermint/issues/3216
-sed -ie 's/cors_allowed_origins.*$/cors_allowed_origins = ["*"]/' "${TMP_DIR}/config/config.toml"
+sed -ie 's/^cors_allowed_origins.*$/cors_allowed_origins = ["*"]/' "${TMP_DIR}/config/config.toml"
 
 # must enable tx index for search and subscribe
 docker run --rm \


### PR DESCRIPTION
Before, QueryClient was only tested via extensions. This adds tests for its two function via both WS and http transport (which matters for the next block header logic)