### PR TITLE
Allow OfflineSigner implementation to override fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   `isSearchBySentFromOrToQuery` and `isSearchByTagsQuery`.
 - @cosmjs/launchpad: Change type of `TxsResponse.logs` and
   `BroadcastTxsResponse.logs` to `unknown[]`.
+- @cosmjs/launchpad: Export `StdSignDoc` and create helpers to make and
+  serialize a `StdSignDoc`: `makeStdSignDoc` and `serializeSignDoc`.
 - @cosmjs/launchpad-ledger: Add package supporting Ledger device integration for
   Launchpad. Two new classes are provided: `LedgerSigner` (for most use cases)
   and `LaunchpadLedger` for more fine-grained access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 - @cosmjs/launchpad: Remove `PrehashType` and the prehash type argument in
   `OfflineSigner.sign` because the signer now needs to know how to serialize an
   `StdSignDoc`.
+- @cosmjs/launchpad: Remove `makeSignBytes` in favour of `makeStdSignDoc` and
+  `serializeSignDoc`.
 - @cosmjs/launchpad-ledger: Add package supporting Ledger device integration for
   Launchpad. Two new classes are provided: `LedgerSigner` (for most use cases)
   and `LaunchpadLedger` for more fine-grained access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
   `BroadcastTxsResponse.logs` to `unknown[]`.
 - @cosmjs/launchpad: Export `StdSignDoc` and create helpers to make and
   serialize a `StdSignDoc`: `makeStdSignDoc` and `serializeSignDoc`.
+- @cosmjs/launchpad: Let `OfflineSigner.sign` take an `StdSignDoc` instead of an
+  encoded message.
 - @cosmjs/launchpad-ledger: Add package supporting Ledger device integration for
   Launchpad. Two new classes are provided: `LedgerSigner` (for most use cases)
   and `LaunchpadLedger` for more fine-grained access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - @cosmjs/launchpad: Create `WrappedTx`, `WrappedStdTx` and `isWrappedStdTx` to
   better represent the Amino tx interface. Deprecate `CosmosSdkTx`, which is an
   alias for `WrappedStdTx`.
+- @cosmjs/launchpad: Add `makeStdTx` to create an `StdTx`.
 - @cosmjs/launchpad-ledger: Add package supporting Ledger device integration for
   Launchpad. Two new classes are provided: `LedgerSigner` (for most use cases)
   and `LaunchpadLedger` for more fine-grained access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,14 +46,14 @@
 - @cosmjs/launchpad: Change type of `TxsResponse.logs` and
   `BroadcastTxsResponse.logs` to `unknown[]`.
 - @cosmjs/launchpad: Export `StdSignDoc` and create helpers to make and
-  serialize a `StdSignDoc`: `makeStdSignDoc` and `serializeSignDoc`.
+  serialize a `StdSignDoc`: `makeSignDoc` and `serializeSignDoc`.
 - @cosmjs/launchpad: Let `OfflineSigner.sign` take an `StdSignDoc` instead of an
   encoded message and return a `SignResponse` that includes the document which
   was signed.
 - @cosmjs/launchpad: Remove `PrehashType` and the prehash type argument in
   `OfflineSigner.sign` because the signer now needs to know how to serialize an
   `StdSignDoc`.
-- @cosmjs/launchpad: Remove `makeSignBytes` in favour of `makeStdSignDoc` and
+- @cosmjs/launchpad: Remove `makeSignBytes` in favour of `makeSignDoc` and
   `serializeSignDoc`.
 - @cosmjs/launchpad-ledger: Add package supporting Ledger device integration for
   Launchpad. Two new classes are provided: `LedgerSigner` (for most use cases)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@
   serialize a `StdSignDoc`: `makeStdSignDoc` and `serializeSignDoc`.
 - @cosmjs/launchpad: Let `OfflineSigner.sign` take an `StdSignDoc` instead of an
   encoded message.
+- @cosmjs/launchpad: Remove `PrehashType` and the prehash type argument in
+  `OfflineSigner.sign` because the signer now needs to know how to serialize an
+  `StdSignDoc`.
 - @cosmjs/launchpad-ledger: Add package supporting Ledger device integration for
   Launchpad. Two new classes are provided: `LedgerSigner` (for most use cases)
   and `LaunchpadLedger` for more fine-grained access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
   `StdSignDoc`.
 - @cosmjs/launchpad: Remove `makeSignBytes` in favour of `makeSignDoc` and
   `serializeSignDoc`.
+- @cosmjs/launchpad: Create `WrappedTx`, `WrappedStdTx` and `isWrappedStdTx` to
+  better represent the Amino tx interface. Deprecate `CosmosSdkTx`, which is an
+  alias for `WrappedStdTx`.
 - @cosmjs/launchpad-ledger: Add package supporting Ledger device integration for
   Launchpad. Two new classes are provided: `LedgerSigner` (for most use cases)
   and `LaunchpadLedger` for more fine-grained access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@
 - @cosmjs/launchpad: Export `StdSignDoc` and create helpers to make and
   serialize a `StdSignDoc`: `makeStdSignDoc` and `serializeSignDoc`.
 - @cosmjs/launchpad: Let `OfflineSigner.sign` take an `StdSignDoc` instead of an
-  encoded message.
+  encoded message and return a `SignResponse` that includes the document which
+  was signed.
 - @cosmjs/launchpad: Remove `PrehashType` and the prehash type argument in
   `OfflineSigner.sign` because the signer now needs to know how to serialize an
   `StdSignDoc`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -66,7 +66,7 @@ const sendTokensMsg: MsgSend = {
   },
 };
 
-const signDoc = makeStdSignDoc(
+const signDoc = makeSignDoc(
   [sendTokensMsg],
   defaultFee,
   defaultNetworkId,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -66,7 +66,7 @@ const sendTokensMsg: MsgSend = {
   },
 };
 
-const signBytes = makeSignBytes(
+const signDoc = makeStdSignDoc(
   [sendTokensMsg],
   defaultFee,
   defaultNetworkId,
@@ -74,7 +74,7 @@ const signBytes = makeSignBytes(
   account_number,
   sequence,
 );
-const signature = await pen.sign(signBytes);
+const { signature } = await wallet.sign(faucetAddress, signDoc);
 const signedTx: StdTx = {
   msg: [sendTokensMsg],
   fee: defaultFee,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,13 +74,8 @@ const signDoc = makeSignDoc(
   account_number,
   sequence,
 );
-const { signature } = await wallet.sign(faucetAddress, signDoc);
-const signedTx: StdTx = {
-  msg: [sendTokensMsg],
-  fee: defaultFee,
-  memo: memo,
-  signatures: [signature],
-};
+const { signed, signature } = await wallet.sign(faucetAddress, signDoc);
+const signedTx = makeStdTx(signed, signature);
 const broadcastResult = await client.broadcastTx(signedTx);
 ```
 

--- a/packages/cli/examples/delegate.ts
+++ b/packages/cli/examples/delegate.ts
@@ -28,13 +28,8 @@ const { accountNumber, sequence } = await client.getSequence(senderAddress);
 console.log("Account/sequence:", accountNumber, sequence);
 
 const signDoc = makeSignDoc([msg], fee, chainId, memo, accountNumber, sequence);
-const { signature } = await wallet.sign(senderAddress, signDoc);
-const signedTx: StdTx = {
-  msg: [msg],
-  fee: fee,
-  memo: memo,
-  signatures: [signature],
-};
+const { signed, signature } = await wallet.sign(senderAddress, signDoc);
+const signedTx = makeStdTx(signed, signature);
 
 const result = await client.broadcastTx(signedTx);
 console.log("Broadcast result:", result);

--- a/packages/cli/examples/delegate.ts
+++ b/packages/cli/examples/delegate.ts
@@ -27,8 +27,8 @@ console.log("Connected to chain:", chainId);
 const { accountNumber, sequence } = await client.getSequence(senderAddress);
 console.log("Account/sequence:", accountNumber, sequence);
 
-const signBytes = makeSignBytes([msg], fee, chainId, memo, accountNumber, sequence);
-const signature = await wallet.sign(senderAddress, signBytes);
+const signDoc = makeStdSignDoc([msg], fee, chainId, memo, accountNumber, sequence);
+const { signature } = await wallet.sign(senderAddress, signDoc);
 const signedTx: StdTx = {
   msg: [msg],
   fee: fee,

--- a/packages/cli/examples/delegate.ts
+++ b/packages/cli/examples/delegate.ts
@@ -27,7 +27,7 @@ console.log("Connected to chain:", chainId);
 const { accountNumber, sequence } = await client.getSequence(senderAddress);
 console.log("Account/sequence:", accountNumber, sequence);
 
-const signDoc = makeStdSignDoc([msg], fee, chainId, memo, accountNumber, sequence);
+const signDoc = makeSignDoc([msg], fee, chainId, memo, accountNumber, sequence);
 const { signature } = await wallet.sign(senderAddress, signDoc);
 const signedTx: StdTx = {
   msg: [msg],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -98,7 +98,7 @@ export async function main(originalArgs: readonly string[]): Promise<void> {
         "encodeSecp256k1Signature",
         "logs",
         "makeCosmoshubPath",
-        "makeStdSignDoc",
+        "makeSignDoc",
         "IndexedTx",
         "BroadcastTxResult",
         "Coin",
@@ -166,7 +166,7 @@ export async function main(originalArgs: readonly string[]): Promise<void> {
         amount: coins(5000000, "ucosm"),
         gas: "89000000",
       };
-      const signDoc = makeStdSignDoc([], fee, "chain-xyz", "hello, world", 1, 2);
+      const signDoc = makeSignDoc([], fee, "chain-xyz", "hello, world", 1, 2);
       const { signed, signature } = await wallet.sign(address, signDoc);
       assert(signed.memo === "hello, world");
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -99,6 +99,7 @@ export async function main(originalArgs: readonly string[]): Promise<void> {
         "logs",
         "makeCosmoshubPath",
         "makeSignBytes",
+        "makeStdSignDoc",
         "IndexedTx",
         "BroadcastTxResult",
         "Coin",
@@ -115,6 +116,7 @@ export async function main(originalArgs: readonly string[]): Promise<void> {
         "Secp256k1Wallet",
         "SigningCosmosClient",
         "StdFee",
+        "StdSignDoc",
         "StdTx",
       ],
     ],
@@ -161,7 +163,13 @@ export async function main(originalArgs: readonly string[]): Promise<void> {
       const wallet = await Secp256k1Wallet.fromMnemonic(mnemonic, makeCosmoshubPath(0));
       const [{ address }] = await wallet.getAccounts();
       const data = toAscii("foo bar");
-      const signature = await wallet.sign(address, data);
+      const fee: StdFee = {
+        amount: coins(5000000, "ucosm"),
+        gas: "89000000",
+      };
+      const signDoc = makeStdSignDoc([], fee, "chain-xyz", "hello, world", 1, 2);
+      const { signed, signature } = await wallet.sign(address, signDoc);
+      assert(signed.memo === "hello, world");
 
       const bechPubkey = "coralvalconspub1zcjduepqvxg72ccnl9r65fv0wn3amlk4sfzqfe2k36l073kjx2qyaf6sk23qw7j8wq";
       assert(encodeBech32Pubkey(decodeBech32Pubkey(bechPubkey), "coralvalconspub") == bechPubkey);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -99,6 +99,7 @@ export async function main(originalArgs: readonly string[]): Promise<void> {
         "logs",
         "makeCosmoshubPath",
         "makeSignDoc",
+        "makeStdTx",
         "IndexedTx",
         "BroadcastTxResult",
         "Coin",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -98,7 +98,6 @@ export async function main(originalArgs: readonly string[]): Promise<void> {
         "encodeSecp256k1Signature",
         "logs",
         "makeCosmoshubPath",
-        "makeSignBytes",
         "makeStdSignDoc",
         "IndexedTx",
         "BroadcastTxResult",

--- a/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
@@ -6,6 +6,7 @@ import {
   isMsgSend,
   LcdClient,
   makeSignDoc,
+  makeStdTx,
   MsgSend,
   Secp256k1Wallet,
   WrappedStdTx,
@@ -104,15 +105,10 @@ describe("CosmWasmClient.searchTx", () => {
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
         const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-        const { signature } = await wallet.sign(alice.address0, signDoc);
+        const { signed, signature } = await wallet.sign(alice.address0, signDoc);
         const tx: WrappedStdTx = {
           type: "cosmos-sdk/StdTx",
-          value: {
-            msg: [sendMsg],
-            fee: fee,
-            memo: memo,
-            signatures: [signature],
-          },
+          value: makeStdTx(signed, signature),
         };
         const transactionId = await client.getIdentifier(tx);
         const result = await client.broadcastTx(tx.value);

--- a/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
@@ -104,7 +104,7 @@ describe("CosmWasmClient.searchTx", () => {
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
         const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(alice.address0, signDoc);
+        const { signature } = await wallet.sign(alice.address0, signDoc);
         const tx: CosmosSdkTx = {
           type: "cosmos-sdk/StdTx",
           value: {

--- a/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
@@ -6,7 +6,7 @@ import {
   isBroadcastTxFailure,
   isMsgSend,
   LcdClient,
-  makeSignBytes,
+  makeStdSignDoc,
   MsgSend,
   Secp256k1Wallet,
 } from "@cosmjs/launchpad";
@@ -103,8 +103,8 @@ describe("CosmWasmClient.searchTx", () => {
         };
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
-        const signBytes = makeSignBytes([sendMsg], fee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(alice.address0, signBytes);
+        const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+        const signature = await wallet.sign(alice.address0, signDoc);
         const tx: CosmosSdkTx = {
           type: "cosmos-sdk/StdTx",
           value: {

--- a/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
@@ -2,13 +2,13 @@
 import {
   Coin,
   coins,
-  CosmosSdkTx,
   isBroadcastTxFailure,
   isMsgSend,
   LcdClient,
   makeSignDoc,
   MsgSend,
   Secp256k1Wallet,
+  WrappedStdTx,
 } from "@cosmjs/launchpad";
 import { assert, sleep } from "@cosmjs/utils";
 
@@ -30,7 +30,7 @@ interface TestTxSend {
   readonly recipient: string;
   readonly hash: string;
   readonly height: number;
-  readonly tx: CosmosSdkTx;
+  readonly tx: WrappedStdTx;
 }
 
 interface TestTxExecute {
@@ -38,7 +38,7 @@ interface TestTxExecute {
   readonly contract: string;
   readonly hash: string;
   readonly height: number;
-  readonly tx: CosmosSdkTx;
+  readonly tx: WrappedStdTx;
 }
 
 describe("CosmWasmClient.searchTx", () => {
@@ -105,7 +105,7 @@ describe("CosmWasmClient.searchTx", () => {
         const chainId = await client.getChainId();
         const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
         const { signature } = await wallet.sign(alice.address0, signDoc);
-        const tx: CosmosSdkTx = {
+        const tx: WrappedStdTx = {
           type: "cosmos-sdk/StdTx",
           value: {
             msg: [sendMsg],

--- a/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.searchtx.spec.ts
@@ -6,7 +6,7 @@ import {
   isBroadcastTxFailure,
   isMsgSend,
   LcdClient,
-  makeStdSignDoc,
+  makeSignDoc,
   MsgSend,
   Secp256k1Wallet,
 } from "@cosmjs/launchpad";
@@ -103,7 +103,7 @@ describe("CosmWasmClient.searchTx", () => {
         };
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
-        const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+        const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
         const { signature } = await wallet.sign(alice.address0, signDoc);
         const tx: CosmosSdkTx = {
           type: "cosmos-sdk/StdTx",

--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -5,10 +5,10 @@ import {
   assertIsBroadcastTxSuccess,
   isWrappedStdTx,
   makeSignDoc,
+  makeStdTx,
   MsgSend,
   Secp256k1Wallet,
   StdFee,
-  StdTx,
 } from "@cosmjs/launchpad";
 import { assert, sleep } from "@cosmjs/utils";
 import { ReadonlyDate } from "readonly-date";
@@ -240,13 +240,8 @@ describe("CosmWasmClient", () => {
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(alice.address0);
       const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-      const { signature } = await wallet.sign(alice.address0, signDoc);
-      const signedTx: StdTx = {
-        msg: [sendMsg],
-        fee: fee,
-        memo: memo,
-        signatures: [signature],
-      };
+      const { signed, signature } = await wallet.sign(alice.address0, signDoc);
+      const signedTx = makeStdTx(signed, signature);
       const result = await client.broadcastTx(signedTx);
       assertIsBroadcastTxSuccess(result);
       const { logs, transactionHash } = result;

--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -3,7 +3,7 @@ import { Sha256 } from "@cosmjs/crypto";
 import { Bech32, fromHex, fromUtf8, toAscii, toBase64 } from "@cosmjs/encoding";
 import {
   assertIsBroadcastTxSuccess,
-  makeStdSignDoc,
+  makeSignDoc,
   MsgSend,
   Secp256k1Wallet,
   StdFee,
@@ -237,7 +237,7 @@ describe("CosmWasmClient", () => {
 
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(alice.address0);
-      const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+      const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
       const { signature } = await wallet.sign(alice.address0, signDoc);
       const signedTx: StdTx = {
         msg: [sendMsg],

--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -7,6 +7,7 @@ import {
   MsgSend,
   Secp256k1Wallet,
   StdFee,
+  StdTx,
 } from "@cosmjs/launchpad";
 import { assert, sleep } from "@cosmjs/utils";
 import { ReadonlyDate } from "readonly-date";
@@ -237,8 +238,8 @@ describe("CosmWasmClient", () => {
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(alice.address0);
       const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-      const signature = await wallet.sign(alice.address0, signDoc);
-      const signedTx = {
+      const { signature } = await wallet.sign(alice.address0, signDoc);
+      const signedTx: StdTx = {
         msg: [sendMsg],
         fee: fee,
         memo: memo,

--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -3,7 +3,7 @@ import { Sha256 } from "@cosmjs/crypto";
 import { Bech32, fromHex, fromUtf8, toAscii, toBase64 } from "@cosmjs/encoding";
 import {
   assertIsBroadcastTxSuccess,
-  makeSignBytes,
+  makeStdSignDoc,
   MsgSend,
   Secp256k1Wallet,
   StdFee,
@@ -236,8 +236,8 @@ describe("CosmWasmClient", () => {
 
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(alice.address0);
-      const signBytes = makeSignBytes([sendMsg], fee, chainId, memo, accountNumber, sequence);
-      const signature = await wallet.sign(alice.address0, signBytes);
+      const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+      const signature = await wallet.sign(alice.address0, signDoc);
       const signedTx = {
         msg: [sendMsg],
         fee: fee,

--- a/packages/cosmwasm/src/cosmwasmclient.spec.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.spec.ts
@@ -3,6 +3,7 @@ import { Sha256 } from "@cosmjs/crypto";
 import { Bech32, fromHex, fromUtf8, toAscii, toBase64 } from "@cosmjs/encoding";
 import {
   assertIsBroadcastTxSuccess,
+  isWrappedStdTx,
   makeSignDoc,
   MsgSend,
   Secp256k1Wallet,
@@ -200,6 +201,7 @@ describe("CosmWasmClient", () => {
     it("works", async () => {
       pendingWithoutWasmd();
       const client = new CosmWasmClient(wasmd.endpoint);
+      assert(isWrappedStdTx(cosmoshub.tx));
       expect(await client.getIdentifier(cosmoshub.tx)).toEqual(cosmoshub.id);
     });
   });

--- a/packages/cosmwasm/src/cosmwasmclient.ts
+++ b/packages/cosmwasm/src/cosmwasmclient.ts
@@ -5,7 +5,6 @@ import {
   BroadcastMode,
   BroadcastTxResult,
   Coin,
-  CosmosSdkTx,
   IndexedTx,
   LcdClient,
   normalizePubkey,
@@ -13,6 +12,7 @@ import {
   setupAuthExtension,
   StdTx,
   uint64ToNumber,
+  WrappedStdTx,
 } from "@cosmjs/launchpad";
 import { Uint53 } from "@cosmjs/math";
 
@@ -199,7 +199,7 @@ export class CosmWasmClient {
   /**
    * Returns a 32 byte upper-case hex transaction hash (typically used as the transaction ID)
    */
-  public async getIdentifier(tx: CosmosSdkTx): Promise<string> {
+  public async getIdentifier(tx: WrappedStdTx): Promise<string> {
     // We consult the REST API because we don't have a local amino encoder
     const response = await this.lcdClient.encodeTx(tx);
     const hash = new Sha256(fromBase64(response.tx)).digest();

--- a/packages/cosmwasm/src/lcdapi/wasm.spec.ts
+++ b/packages/cosmwasm/src/lcdapi/wasm.spec.ts
@@ -10,7 +10,7 @@ import {
   coin,
   coins,
   LcdClient,
-  makeSignBytes,
+  makeStdSignDoc,
   OfflineSigner,
   Secp256k1Wallet,
   setupAuthExtension,
@@ -125,8 +125,8 @@ async function executeContract(
   };
 
   const { account_number, sequence } = (await client.auth.account(alice.address0)).result.value;
-  const signBytes = makeSignBytes([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
-  const signature = await signer.sign(alice.address0, signBytes);
+  const signDoc = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
+  const signature = await signer.sign(alice.address0, signDoc);
   const signedTx = makeSignedTx(theMsg, fee, memo, signature);
   return client.broadcastTx(signedTx);
 }

--- a/packages/cosmwasm/src/lcdapi/wasm.spec.ts
+++ b/packages/cosmwasm/src/lcdapi/wasm.spec.ts
@@ -10,7 +10,7 @@ import {
   coin,
   coins,
   LcdClient,
-  makeStdSignDoc,
+  makeSignDoc,
   OfflineSigner,
   Secp256k1Wallet,
   setupAuthExtension,
@@ -125,7 +125,7 @@ async function executeContract(
   };
 
   const { account_number, sequence } = (await client.auth.account(alice.address0)).result.value;
-  const signDoc = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
+  const signDoc = makeSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
   const { signature } = await signer.sign(alice.address0, signDoc);
   const signedTx = makeSignedTx(theMsg, fee, memo, signature);
   return client.broadcastTx(signedTx);

--- a/packages/cosmwasm/src/lcdapi/wasm.spec.ts
+++ b/packages/cosmwasm/src/lcdapi/wasm.spec.ts
@@ -126,7 +126,7 @@ async function executeContract(
 
   const { account_number, sequence } = (await client.auth.account(alice.address0)).result.value;
   const signDoc = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
-  const signature = await signer.sign(alice.address0, signDoc);
+  const { signature } = await signer.sign(alice.address0, signDoc);
   const signedTx = makeSignedTx(theMsg, fee, memo, signature);
   return client.broadcastTx(signedTx);
 }

--- a/packages/cosmwasm/src/lcdapi/wasm.spec.ts
+++ b/packages/cosmwasm/src/lcdapi/wasm.spec.ts
@@ -11,6 +11,7 @@ import {
   coins,
   LcdClient,
   makeSignDoc,
+  makeStdTx,
   OfflineSigner,
   Secp256k1Wallet,
   setupAuthExtension,
@@ -36,7 +37,6 @@ import {
   fromOneElementArray,
   getHackatom,
   makeRandomAddress,
-  makeSignedTx,
   pendingWithoutWasmd,
   wasmd,
   wasmdEnabled,
@@ -126,8 +126,8 @@ async function executeContract(
 
   const { account_number, sequence } = (await client.auth.account(alice.address0)).result.value;
   const signDoc = makeSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
-  const { signature } = await signer.sign(alice.address0, signDoc);
-  const signedTx = makeSignedTx(theMsg, fee, memo, signature);
+  const { signed, signature } = await signer.sign(alice.address0, signDoc);
+  const signedTx = makeStdTx(signed, signature);
   return client.broadcastTx(signedTx);
 }
 

--- a/packages/cosmwasm/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm/src/signingcosmwasmclient.ts
@@ -11,7 +11,7 @@ import {
   GasLimits,
   GasPrice,
   isBroadcastTxFailure,
-  makeSignBytes,
+  makeStdSignDoc,
   Msg,
   MsgSend,
   OfflineSigner,
@@ -360,8 +360,8 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   public async signAndBroadcast(msgs: readonly Msg[], fee: StdFee, memo = ""): Promise<BroadcastTxResult> {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
-    const signBytes = makeSignBytes(msgs, fee, chainId, memo, accountNumber, sequence);
-    const signature = await this.signer.sign(this.senderAddress, signBytes);
+    const signDoc = makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
+    const signature = await this.signer.sign(this.senderAddress, signDoc);
     const signedTx: StdTx = {
       msg: msgs,
       fee: fee,

--- a/packages/cosmwasm/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm/src/signingcosmwasmclient.ts
@@ -11,7 +11,7 @@ import {
   GasLimits,
   GasPrice,
   isBroadcastTxFailure,
-  makeStdSignDoc,
+  makeSignDoc,
   Msg,
   MsgSend,
   OfflineSigner,
@@ -360,7 +360,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
   public async signAndBroadcast(msgs: readonly Msg[], fee: StdFee, memo = ""): Promise<BroadcastTxResult> {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
-    const signDoc = makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
+    const signDoc = makeSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
     const { signature } = await this.signer.sign(this.senderAddress, signDoc);
     const signedTx: StdTx = {
       msg: msgs,

--- a/packages/cosmwasm/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm/src/signingcosmwasmclient.ts
@@ -361,7 +361,7 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
     const signDoc = makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
-    const signature = await this.signer.sign(this.senderAddress, signDoc);
+    const { signature } = await this.signer.sign(this.senderAddress, signDoc);
     const signedTx: StdTx = {
       msg: msgs,
       fee: fee,

--- a/packages/cosmwasm/src/signingcosmwasmclient.ts
+++ b/packages/cosmwasm/src/signingcosmwasmclient.ts
@@ -12,11 +12,11 @@ import {
   GasPrice,
   isBroadcastTxFailure,
   makeSignDoc,
+  makeStdTx,
   Msg,
   MsgSend,
   OfflineSigner,
   StdFee,
-  StdTx,
 } from "@cosmjs/launchpad";
 import { Uint53 } from "@cosmjs/math";
 import pako from "pako";
@@ -361,13 +361,8 @@ export class SigningCosmWasmClient extends CosmWasmClient {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
     const signDoc = makeSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
-    const { signature } = await this.signer.sign(this.senderAddress, signDoc);
-    const signedTx: StdTx = {
-      msg: msgs,
-      fee: fee,
-      memo: memo,
-      signatures: [signature],
-    };
+    const { signed, signature } = await this.signer.sign(this.senderAddress, signDoc);
+    const signedTx = makeStdTx(signed, signature);
     return this.broadcastTx(signedTx);
   }
 }

--- a/packages/cosmwasm/src/testutils.spec.ts
+++ b/packages/cosmwasm/src/testutils.spec.ts
@@ -1,6 +1,5 @@
 import { Random } from "@cosmjs/crypto";
 import { Bech32, fromBase64 } from "@cosmjs/encoding";
-import { Msg, StdFee, StdSignature, StdTx } from "@cosmjs/launchpad";
 
 import hackatom from "./testdata/contract.json";
 
@@ -88,13 +87,4 @@ export function pendingWithoutWasmd(): void {
 export function fromOneElementArray<T>(elements: ArrayLike<T>): T {
   if (elements.length !== 1) throw new Error(`Expected exactly one element but got ${elements.length}`);
   return elements[0];
-}
-
-export function makeSignedTx(firstMsg: Msg, fee: StdFee, memo: string, firstSignature: StdSignature): StdTx {
-  return {
-    msg: [firstMsg],
-    fee: fee,
-    memo: memo,
-    signatures: [firstSignature],
-  };
 }

--- a/packages/cosmwasm/types/cosmwasmclient.d.ts
+++ b/packages/cosmwasm/types/cosmwasmclient.d.ts
@@ -3,11 +3,11 @@ import {
   BroadcastMode,
   BroadcastTxResult,
   Coin,
-  CosmosSdkTx,
   IndexedTx,
   LcdClient,
   PubKey,
   StdTx,
+  WrappedStdTx,
 } from "@cosmjs/launchpad";
 import { WasmExtension } from "./lcdapi/wasm";
 import { JsonObject } from "./types";
@@ -132,7 +132,7 @@ export declare class CosmWasmClient {
   /**
    * Returns a 32 byte upper-case hex transaction hash (typically used as the transaction ID)
    */
-  getIdentifier(tx: CosmosSdkTx): Promise<string>;
+  getIdentifier(tx: WrappedStdTx): Promise<string>;
   /**
    * Returns account number and sequence.
    *

--- a/packages/launchpad-ledger/demo/index.html
+++ b/packages/launchpad-ledger/demo/index.html
@@ -34,7 +34,7 @@
     </div>
     <div>
       <label>Message</label>
-      <textarea id="message">
+      <textarea id="sign-doc">
       </textarea>
     </div>
     <div>

--- a/packages/launchpad-ledger/src/demo/node.ts
+++ b/packages/launchpad-ledger/src/demo/node.ts
@@ -56,5 +56,6 @@ export async function sign(
     accountNumber,
     defaultSequence,
   );
-  return signer.sign(fromAddress, signDoc);
+  const { signature } = await signer.sign(fromAddress, signDoc);
+  return signature;
 }

--- a/packages/launchpad-ledger/src/demo/node.ts
+++ b/packages/launchpad-ledger/src/demo/node.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { toBase64 } from "@cosmjs/encoding";
-import { makeCosmoshubPath, makeSignBytes, StdFee, StdSignature } from "@cosmjs/launchpad";
+import { makeCosmoshubPath, makeStdSignDoc, StdFee, StdSignature } from "@cosmjs/launchpad";
 
 import { LedgerSigner } from "../ledgersigner";
 
@@ -48,7 +48,7 @@ export async function sign(
       },
     },
   ];
-  const signBytes = makeSignBytes(
+  const signDoc = makeStdSignDoc(
     msgs,
     defaultFee,
     defaultChainId,
@@ -56,5 +56,5 @@ export async function sign(
     accountNumber,
     defaultSequence,
   );
-  return signer.sign(fromAddress, signBytes);
+  return signer.sign(fromAddress, signDoc);
 }

--- a/packages/launchpad-ledger/src/demo/node.ts
+++ b/packages/launchpad-ledger/src/demo/node.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { toBase64 } from "@cosmjs/encoding";
-import { makeCosmoshubPath, makeStdSignDoc, StdFee, StdSignature } from "@cosmjs/launchpad";
+import { makeCosmoshubPath, makeSignDoc, StdFee, StdSignature } from "@cosmjs/launchpad";
 
 import { LedgerSigner } from "../ledgersigner";
 
@@ -48,14 +48,7 @@ export async function sign(
       },
     },
   ];
-  const signDoc = makeStdSignDoc(
-    msgs,
-    defaultFee,
-    defaultChainId,
-    defaultMemo,
-    accountNumber,
-    defaultSequence,
-  );
+  const signDoc = makeSignDoc(msgs, defaultFee, defaultChainId, defaultMemo, accountNumber, defaultSequence);
   const { signature } = await signer.sign(fromAddress, signDoc);
   return signature;
 }

--- a/packages/launchpad-ledger/src/ledgersigner.ts
+++ b/packages/launchpad-ledger/src/ledgersigner.ts
@@ -48,7 +48,7 @@ export class LedgerSigner implements OfflineSigner {
     const hdPath = this.hdPaths[accountIndex];
     const signature = await this.ledger.sign(message, hdPath);
     return {
-      signedDoc: signDoc,
+      signed: signDoc,
       signature: encodeSecp256k1Signature(accountForAddress.pubkey, signature),
     };
   }

--- a/packages/launchpad-ledger/src/ledgersigner.ts
+++ b/packages/launchpad-ledger/src/ledgersigner.ts
@@ -4,10 +4,9 @@ import {
   encodeSecp256k1Signature,
   makeCosmoshubPath,
   OfflineSigner,
-  StdSignature,
   StdSignDoc,
 } from "@cosmjs/launchpad";
-import { serializeSignDoc } from "@cosmjs/launchpad";
+import { serializeSignDoc, SignResponse } from "@cosmjs/launchpad";
 
 import { LaunchpadLedger, LaunchpadLedgerOptions } from "./launchpadledger";
 
@@ -36,7 +35,7 @@ export class LedgerSigner implements OfflineSigner {
     return this.accounts;
   }
 
-  public async sign(signerAddress: string, signDoc: StdSignDoc): Promise<StdSignature> {
+  public async sign(signerAddress: string, signDoc: StdSignDoc): Promise<SignResponse> {
     const accounts = this.accounts || (await this.getAccounts());
     const accountIndex = accounts.findIndex((account) => account.address === signerAddress);
 
@@ -48,6 +47,9 @@ export class LedgerSigner implements OfflineSigner {
     const accountForAddress = accounts[accountIndex];
     const hdPath = this.hdPaths[accountIndex];
     const signature = await this.ledger.sign(message, hdPath);
-    return encodeSecp256k1Signature(accountForAddress.pubkey, signature);
+    return {
+      signedDoc: signDoc,
+      signature: encodeSecp256k1Signature(accountForAddress.pubkey, signature),
+    };
   }
 }

--- a/packages/launchpad-ledger/src/ledgersigner.ts
+++ b/packages/launchpad-ledger/src/ledgersigner.ts
@@ -5,7 +5,9 @@ import {
   makeCosmoshubPath,
   OfflineSigner,
   StdSignature,
+  StdSignDoc,
 } from "@cosmjs/launchpad";
+import { serializeSignDoc } from "@cosmjs/launchpad";
 
 import { LaunchpadLedger, LaunchpadLedgerOptions } from "./launchpadledger";
 
@@ -34,14 +36,15 @@ export class LedgerSigner implements OfflineSigner {
     return this.accounts;
   }
 
-  public async sign(address: string, message: Uint8Array): Promise<StdSignature> {
+  public async sign(signerAddress: string, signDoc: StdSignDoc): Promise<StdSignature> {
     const accounts = this.accounts || (await this.getAccounts());
-    const accountIndex = accounts.findIndex((account) => account.address === address);
+    const accountIndex = accounts.findIndex((account) => account.address === signerAddress);
 
     if (accountIndex === -1) {
-      throw new Error(`Address ${address} not found in wallet`);
+      throw new Error(`Address ${signerAddress} not found in wallet`);
     }
 
+    const message = serializeSignDoc(signDoc);
     const accountForAddress = accounts[accountIndex];
     const hdPath = this.hdPaths[accountIndex];
     const signature = await this.ledger.sign(message, hdPath);

--- a/packages/launchpad-ledger/types/ledgersigner.d.ts
+++ b/packages/launchpad-ledger/types/ledgersigner.d.ts
@@ -1,4 +1,4 @@
-import { AccountData, OfflineSigner, StdSignature } from "@cosmjs/launchpad";
+import { AccountData, OfflineSigner, StdSignature, StdSignDoc } from "@cosmjs/launchpad";
 import { LaunchpadLedgerOptions } from "./launchpadledger";
 export declare class LedgerSigner implements OfflineSigner {
   private readonly ledger;
@@ -6,5 +6,5 @@ export declare class LedgerSigner implements OfflineSigner {
   private accounts?;
   constructor(options?: LaunchpadLedgerOptions);
   getAccounts(): Promise<readonly AccountData[]>;
-  sign(address: string, message: Uint8Array): Promise<StdSignature>;
+  sign(signerAddress: string, signDoc: StdSignDoc): Promise<StdSignature>;
 }

--- a/packages/launchpad-ledger/types/ledgersigner.d.ts
+++ b/packages/launchpad-ledger/types/ledgersigner.d.ts
@@ -1,4 +1,5 @@
-import { AccountData, OfflineSigner, StdSignature, StdSignDoc } from "@cosmjs/launchpad";
+import { AccountData, OfflineSigner, StdSignDoc } from "@cosmjs/launchpad";
+import { SignResponse } from "@cosmjs/launchpad";
 import { LaunchpadLedgerOptions } from "./launchpadledger";
 export declare class LedgerSigner implements OfflineSigner {
   private readonly ledger;
@@ -6,5 +7,5 @@ export declare class LedgerSigner implements OfflineSigner {
   private accounts?;
   constructor(options?: LaunchpadLedgerOptions);
   getAccounts(): Promise<readonly AccountData[]>;
-  sign(signerAddress: string, signDoc: StdSignDoc): Promise<StdSignature>;
+  sign(signerAddress: string, signDoc: StdSignDoc): Promise<SignResponse>;
 }

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -205,14 +205,7 @@ const memo = "Time for action";
 const { account_number, sequence } = (
   await client.auth.account(myAddress)
 ).result.value;
-const signDoc = makeSignDoc(
-  [msg],
-  fee,
-  apiUrl,
-  memo,
-  account_number,
-  sequence,
-);
+const signDoc = makeSignDoc([msg], fee, apiUrl, memo, account_number, sequence);
 const { signature } = await signer.sign(myAddress, signDoc);
 const signedTx: StdTx = {
   msg: [msg],

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -173,7 +173,7 @@ import { MsgExecuteContract, setupWasmExtension } from "@cosmjs/cosmwasm";
 import {
   assertIsPostTxSuccess,
   LcdClient,
-  makeStdSignDoc,
+  makeSignDoc,
   setupAuthExtension,
   StdFee,
   StdTx,
@@ -205,7 +205,7 @@ const memo = "Time for action";
 const { account_number, sequence } = (
   await client.auth.account(myAddress)
 ).result.value;
-const signDoc = makeStdSignDoc(
+const signDoc = makeSignDoc(
   [msg],
   fee,
   apiUrl,

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -206,13 +206,8 @@ const { account_number, sequence } = (
   await client.auth.account(myAddress)
 ).result.value;
 const signDoc = makeSignDoc([msg], fee, apiUrl, memo, account_number, sequence);
-const { signature } = await signer.sign(myAddress, signDoc);
-const signedTx: StdTx = {
-  msg: [msg],
-  fee: fee,
-  memo: memo,
-  signatures: [signature],
-};
+const { signed, signature } = await signer.sign(myAddress, signDoc);
+const signedTx = makeStdTx(signed, signature);
 const result = await client.postTx(signedTx);
 assertIsPostTxSuccess(result);
 ```

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -173,7 +173,7 @@ import { MsgExecuteContract, setupWasmExtension } from "@cosmjs/cosmwasm";
 import {
   assertIsPostTxSuccess,
   LcdClient,
-  makeSignBytes,
+  makeStdSignDoc,
   setupAuthExtension,
   StdFee,
   StdTx,
@@ -205,7 +205,7 @@ const memo = "Time for action";
 const { account_number, sequence } = (
   await client.auth.account(myAddress)
 ).result.value;
-const signBytes = makeSignBytes(
+const signDoc = makeStdSignDoc(
   [msg],
   fee,
   apiUrl,
@@ -213,7 +213,7 @@ const signBytes = makeSignBytes(
   account_number,
   sequence,
 );
-const signature = await signer.sign(myAddress, signBytes);
+const { signature } = await signer.sign(myAddress, signDoc);
 const signedTx: StdTx = {
   msg: [msg],
   fee: fee,

--- a/packages/launchpad/src/cosmosclient.searchtx.spec.ts
+++ b/packages/launchpad/src/cosmosclient.searchtx.spec.ts
@@ -16,7 +16,7 @@ import {
   wasmd,
   wasmdEnabled,
 } from "./testutils.spec";
-import { WrappedStdTx } from "./tx";
+import { makeStdTx, WrappedStdTx } from "./tx";
 
 interface TestTxSend {
   readonly sender: string;
@@ -56,15 +56,10 @@ describe("CosmosClient.searchTx", () => {
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
         const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-        const { signature } = await wallet.sign(walletAddress, signDoc);
+        const { signed, signature } = await wallet.sign(walletAddress, signDoc);
         const tx: WrappedStdTx = {
           type: "cosmos-sdk/StdTx",
-          value: {
-            msg: [sendMsg],
-            fee: fee,
-            memo: memo,
-            signatures: [signature],
-          },
+          value: makeStdTx(signed, signature),
         };
         const transactionId = await client.getIdentifier(tx);
         const result = await client.broadcastTx(tx.value);

--- a/packages/launchpad/src/cosmosclient.searchtx.spec.ts
+++ b/packages/launchpad/src/cosmosclient.searchtx.spec.ts
@@ -3,7 +3,7 @@ import { assert, sleep } from "@cosmjs/utils";
 
 import { coins } from "./coins";
 import { CosmosClient, isBroadcastTxFailure } from "./cosmosclient";
-import { makeStdSignDoc } from "./encoding";
+import { makeSignDoc } from "./encoding";
 import { LcdClient } from "./lcdapi";
 import { isMsgSend, MsgSend } from "./msgs";
 import { Secp256k1Wallet } from "./secp256k1wallet";
@@ -55,7 +55,7 @@ describe("CosmosClient.searchTx", () => {
         };
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
-        const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+        const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
         const { signature } = await wallet.sign(walletAddress, signDoc);
         const tx: CosmosSdkTx = {
           type: "cosmos-sdk/StdTx",

--- a/packages/launchpad/src/cosmosclient.searchtx.spec.ts
+++ b/packages/launchpad/src/cosmosclient.searchtx.spec.ts
@@ -3,7 +3,7 @@ import { assert, sleep } from "@cosmjs/utils";
 
 import { coins } from "./coins";
 import { CosmosClient, isBroadcastTxFailure } from "./cosmosclient";
-import { makeSignBytes } from "./encoding";
+import { makeStdSignDoc } from "./encoding";
 import { LcdClient } from "./lcdapi";
 import { isMsgSend, MsgSend } from "./msgs";
 import { Secp256k1Wallet } from "./secp256k1wallet";
@@ -55,8 +55,8 @@ describe("CosmosClient.searchTx", () => {
         };
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
-        const signBytes = makeSignBytes([sendMsg], fee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(walletAddress, signBytes);
+        const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+        const signature = await wallet.sign(walletAddress, signDoc);
         const tx: CosmosSdkTx = {
           type: "cosmos-sdk/StdTx",
           value: {

--- a/packages/launchpad/src/cosmosclient.searchtx.spec.ts
+++ b/packages/launchpad/src/cosmosclient.searchtx.spec.ts
@@ -56,7 +56,7 @@ describe("CosmosClient.searchTx", () => {
         const { accountNumber, sequence } = await client.getSequence();
         const chainId = await client.getChainId();
         const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(walletAddress, signDoc);
+        const { signature } = await wallet.sign(walletAddress, signDoc);
         const tx: CosmosSdkTx = {
           type: "cosmos-sdk/StdTx",
           value: {

--- a/packages/launchpad/src/cosmosclient.searchtx.spec.ts
+++ b/packages/launchpad/src/cosmosclient.searchtx.spec.ts
@@ -16,14 +16,14 @@ import {
   wasmd,
   wasmdEnabled,
 } from "./testutils.spec";
-import { CosmosSdkTx } from "./types";
+import { WrappedStdTx } from "./tx";
 
 interface TestTxSend {
   readonly sender: string;
   readonly recipient: string;
   readonly hash: string;
   readonly height: number;
-  readonly tx: CosmosSdkTx;
+  readonly tx: WrappedStdTx;
 }
 
 describe("CosmosClient.searchTx", () => {
@@ -57,7 +57,7 @@ describe("CosmosClient.searchTx", () => {
         const chainId = await client.getChainId();
         const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
         const { signature } = await wallet.sign(walletAddress, signDoc);
-        const tx: CosmosSdkTx = {
+        const tx: WrappedStdTx = {
           type: "cosmos-sdk/StdTx",
           value: {
             msg: [sendMsg],

--- a/packages/launchpad/src/cosmosclient.spec.ts
+++ b/packages/launchpad/src/cosmosclient.spec.ts
@@ -16,7 +16,7 @@ import {
   unused,
   wasmd,
 } from "./testutils.spec";
-import { StdFee } from "./types";
+import { StdFee, StdTx } from "./types";
 
 const blockTime = 1_000; // ms
 
@@ -230,8 +230,8 @@ describe("CosmosClient", () => {
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(faucet.address);
       const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-      const signature = await wallet.sign(walletAddress, signDoc);
-      const signedTx = {
+      const { signature } = await wallet.sign(walletAddress, signDoc);
+      const signedTx: StdTx = {
         msg: [sendMsg],
         fee: fee,
         memo: memo,

--- a/packages/launchpad/src/cosmosclient.spec.ts
+++ b/packages/launchpad/src/cosmosclient.spec.ts
@@ -3,7 +3,7 @@ import { sleep } from "@cosmjs/utils";
 import { ReadonlyDate } from "readonly-date";
 
 import { assertIsBroadcastTxSuccess, CosmosClient, PrivateCosmosClient } from "./cosmosclient";
-import { makeStdSignDoc } from "./encoding";
+import { makeSignDoc } from "./encoding";
 import { findAttribute } from "./logs";
 import { MsgSend } from "./msgs";
 import { Secp256k1Wallet } from "./secp256k1wallet";
@@ -229,7 +229,7 @@ describe("CosmosClient", () => {
 
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(faucet.address);
-      const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+      const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
       const { signature } = await wallet.sign(walletAddress, signDoc);
       const signedTx: StdTx = {
         msg: [sendMsg],

--- a/packages/launchpad/src/cosmosclient.spec.ts
+++ b/packages/launchpad/src/cosmosclient.spec.ts
@@ -3,7 +3,7 @@ import { sleep } from "@cosmjs/utils";
 import { ReadonlyDate } from "readonly-date";
 
 import { assertIsBroadcastTxSuccess, CosmosClient, PrivateCosmosClient } from "./cosmosclient";
-import { makeSignBytes } from "./encoding";
+import { makeStdSignDoc } from "./encoding";
 import { findAttribute } from "./logs";
 import { MsgSend } from "./msgs";
 import { Secp256k1Wallet } from "./secp256k1wallet";
@@ -229,8 +229,8 @@ describe("CosmosClient", () => {
 
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(faucet.address);
-      const signBytes = makeSignBytes([sendMsg], fee, chainId, memo, accountNumber, sequence);
-      const signature = await wallet.sign(walletAddress, signBytes);
+      const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+      const signature = await wallet.sign(walletAddress, signDoc);
       const signedTx = {
         msg: [sendMsg],
         fee: fee,

--- a/packages/launchpad/src/cosmosclient.spec.ts
+++ b/packages/launchpad/src/cosmosclient.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { sleep } from "@cosmjs/utils";
+import { assert, sleep } from "@cosmjs/utils";
 import { ReadonlyDate } from "readonly-date";
 
 import { assertIsBroadcastTxSuccess, CosmosClient, PrivateCosmosClient } from "./cosmosclient";
@@ -16,7 +16,8 @@ import {
   unused,
   wasmd,
 } from "./testutils.spec";
-import { StdFee, StdTx } from "./types";
+import { isWrappedStdTx, StdTx } from "./tx";
+import { StdFee } from "./types";
 
 const blockTime = 1_000; // ms
 
@@ -190,6 +191,7 @@ describe("CosmosClient", () => {
     it("works", async () => {
       pendingWithoutWasmd();
       const client = new CosmosClient(wasmd.endpoint);
+      assert(isWrappedStdTx(cosmoshub.tx));
       expect(await client.getIdentifier(cosmoshub.tx)).toEqual(cosmoshub.id);
     });
   });

--- a/packages/launchpad/src/cosmosclient.spec.ts
+++ b/packages/launchpad/src/cosmosclient.spec.ts
@@ -16,7 +16,7 @@ import {
   unused,
   wasmd,
 } from "./testutils.spec";
-import { isWrappedStdTx, StdTx } from "./tx";
+import { isWrappedStdTx, makeStdTx } from "./tx";
 import { StdFee } from "./types";
 
 const blockTime = 1_000; // ms
@@ -232,13 +232,8 @@ describe("CosmosClient", () => {
       const chainId = await client.getChainId();
       const { accountNumber, sequence } = await client.getSequence(faucet.address);
       const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-      const { signature } = await wallet.sign(walletAddress, signDoc);
-      const signedTx: StdTx = {
-        msg: [sendMsg],
-        fee: fee,
-        memo: memo,
-        signatures: [signature],
-      };
+      const { signed, signature } = await wallet.sign(walletAddress, signDoc);
+      const signedTx = makeStdTx(signed, signature);
       const txResult = await client.broadcastTx(signedTx);
       assertIsBroadcastTxSuccess(txResult);
       const { logs, transactionHash } = txResult;

--- a/packages/launchpad/src/cosmosclient.ts
+++ b/packages/launchpad/src/cosmosclient.ts
@@ -12,7 +12,8 @@ import {
   uint64ToNumber,
 } from "./lcdapi";
 import { Log, parseLogs } from "./logs";
-import { CosmosSdkTx, PubKey, StdTx } from "./types";
+import { StdTx, WrappedStdTx } from "./tx";
+import { PubKey } from "./types";
 
 export interface GetSequenceResult {
   readonly accountNumber: number;
@@ -121,7 +122,7 @@ export interface IndexedTx {
   readonly code: number;
   readonly rawLog: string;
   readonly logs: readonly Log[];
-  readonly tx: CosmosSdkTx;
+  readonly tx: WrappedStdTx;
   /** The gas limit as set by the user */
   readonly gasWanted?: number;
   /** The gas used by the execution */
@@ -203,7 +204,7 @@ export class CosmosClient {
   /**
    * Returns a 32 byte upper-case hex transaction hash (typically used as the transaction ID)
    */
-  public async getIdentifier(tx: CosmosSdkTx): Promise<string> {
+  public async getIdentifier(tx: WrappedStdTx): Promise<string> {
     // We consult the REST API because we don't have a local amino encoder
     const response = await this.lcdClient.encodeTx(tx);
     const hash = new Sha256(fromBase64(response.tx)).digest();

--- a/packages/launchpad/src/encoding.ts
+++ b/packages/launchpad/src/encoding.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { toUtf8 } from "@cosmjs/encoding";
+import { Uint53 } from "@cosmjs/math";
 
-import { uint64ToString } from "./lcdapi";
 import { Msg } from "./msgs";
 import { StdFee } from "./types";
 
@@ -47,8 +47,8 @@ export function makeSignDoc(
 ): StdSignDoc {
   return {
     chain_id: chainId,
-    account_number: uint64ToString(accountNumber),
-    sequence: uint64ToString(sequence),
+    account_number: Uint53.fromString(accountNumber.toString()).toString(),
+    sequence: Uint53.fromString(sequence.toString()).toString(),
     fee: fee,
     msgs: msgs,
     memo: memo,

--- a/packages/launchpad/src/encoding.ts
+++ b/packages/launchpad/src/encoding.ts
@@ -59,15 +59,3 @@ export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
   const sortedSignDoc = sortJson(signDoc);
   return toUtf8(JSON.stringify(sortedSignDoc));
 }
-
-/** A convenience helper to create the StdSignDoc and serialize it */
-export function makeSignBytes(
-  msgs: readonly Msg[],
-  fee: StdFee,
-  chainId: string,
-  memo: string,
-  accountNumber: number | string,
-  sequence: number | string,
-): Uint8Array {
-  return serializeSignDoc(makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence));
-}

--- a/packages/launchpad/src/encoding.ts
+++ b/packages/launchpad/src/encoding.ts
@@ -29,14 +29,38 @@ function sortJson(json: any): any {
  * @see https://docs.cosmos.network/master/modules/auth/03_types.html#stdsigndoc
  */
 export interface StdSignDoc {
-  readonly account_number: string;
   readonly chain_id: string;
-  readonly fee: StdFee;
-  readonly memo: string;
-  readonly msgs: readonly Msg[];
+  readonly account_number: string;
   readonly sequence: string;
+  readonly fee: StdFee;
+  readonly msgs: readonly Msg[];
+  readonly memo: string;
 }
 
+export function makeStdSignDoc(
+  msgs: readonly Msg[],
+  fee: StdFee,
+  chainId: string,
+  memo: string,
+  accountNumber: number | string,
+  sequence: number | string,
+): StdSignDoc {
+  return {
+    chain_id: chainId,
+    account_number: uint64ToString(accountNumber),
+    sequence: uint64ToString(sequence),
+    fee: fee,
+    msgs: msgs,
+    memo: memo,
+  };
+}
+
+export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
+  const sortedSignDoc = sortJson(signDoc);
+  return toUtf8(JSON.stringify(sortedSignDoc));
+}
+
+/** A convenience helper to create the StdSignDoc and serialize it */
 export function makeSignBytes(
   msgs: readonly Msg[],
   fee: StdFee,
@@ -45,14 +69,5 @@ export function makeSignBytes(
   accountNumber: number | string,
   sequence: number | string,
 ): Uint8Array {
-  const signDoc: StdSignDoc = {
-    account_number: uint64ToString(accountNumber),
-    chain_id: chainId,
-    fee: fee,
-    memo: memo,
-    msgs: msgs,
-    sequence: uint64ToString(sequence),
-  };
-  const sortedSignDoc = sortJson(signDoc);
-  return toUtf8(JSON.stringify(sortedSignDoc));
+  return serializeSignDoc(makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence));
 }

--- a/packages/launchpad/src/encoding.ts
+++ b/packages/launchpad/src/encoding.ts
@@ -37,7 +37,7 @@ export interface StdSignDoc {
   readonly memo: string;
 }
 
-export function makeStdSignDoc(
+export function makeSignDoc(
   msgs: readonly Msg[],
   fee: StdFee,
   chainId: string,

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -28,7 +28,7 @@ export {
   isSearchBySentFromOrToQuery,
   isSearchByTagsQuery,
 } from "./cosmosclient";
-export { makeSignBytes, StdSignDoc } from "./encoding";
+export { makeSignBytes, makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
 export { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 export {
   AuthAccountsResponse,

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -100,7 +100,7 @@ export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
 export { AccountData, Algo, OfflineSigner, SignResponse } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
-export { isStdTx, isWrappedStdTx, CosmosSdkTx, StdTx, WrappedStdTx, WrappedTx } from "./tx";
+export { isStdTx, isWrappedStdTx, makeStdTx, CosmosSdkTx, StdTx, WrappedStdTx, WrappedTx } from "./tx";
 export { pubkeyType, PubKey, StdFee, StdSignature } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";
 export { extractKdfConfiguration, Secp256k1Wallet } from "./secp256k1wallet";

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -28,7 +28,7 @@ export {
   isSearchBySentFromOrToQuery,
   isSearchByTagsQuery,
 } from "./cosmosclient";
-export { makeSignBytes, makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
+export { makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
 export { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 export {
   AuthAccountsResponse,

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -28,7 +28,7 @@ export {
   isSearchBySentFromOrToQuery,
   isSearchByTagsQuery,
 } from "./cosmosclient";
-export { makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
+export { makeSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
 export { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 export {
   AuthAccountsResponse,

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -100,6 +100,7 @@ export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
 export { AccountData, Algo, OfflineSigner, SignResponse } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
-export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
+export { isStdTx, isWrappedStdTx, CosmosSdkTx, StdTx, WrappedStdTx, WrappedTx } from "./tx";
+export { pubkeyType, PubKey, StdFee, StdSignature } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";
 export { extractKdfConfiguration, Secp256k1Wallet } from "./secp256k1wallet";

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -98,15 +98,8 @@ export {
 } from "./pubkey";
 export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
+export { AccountData, Algo, PrehashType, OfflineSigner } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
 export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
-export {
-  AccountData,
-  Algo,
-  PrehashType,
-  OfflineSigner,
-  makeCosmoshubPath,
-  executeKdf,
-  KdfConfiguration,
-} from "./wallet";
+export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";
 export { extractKdfConfiguration, Secp256k1Wallet } from "./secp256k1wallet";

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -98,7 +98,7 @@ export {
 } from "./pubkey";
 export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
-export { AccountData, Algo, PrehashType, OfflineSigner } from "./signer";
+export { AccountData, Algo, OfflineSigner } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
 export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -98,7 +98,7 @@ export {
 } from "./pubkey";
 export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
-export { AccountData, Algo, OfflineSigner } from "./signer";
+export { AccountData, Algo, OfflineSigner, SignResponse } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
 export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";

--- a/packages/launchpad/src/lcdapi/base.ts
+++ b/packages/launchpad/src/lcdapi/base.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { CosmosSdkTx } from "../types";
+import { WrappedStdTx } from "../tx";
 
 /**
  * The mode used to send transaction
@@ -109,7 +109,7 @@ export interface TxsResponse {
   readonly code?: number;
   readonly raw_log: string;
   readonly logs?: unknown[];
-  readonly tx: CosmosSdkTx;
+  readonly tx: WrappedStdTx;
   /** The gas limit as set by the user */
   readonly gas_wanted?: string;
   /** The gas used by the execution */

--- a/packages/launchpad/src/lcdapi/distribution.spec.ts
+++ b/packages/launchpad/src/lcdapi/distribution.spec.ts
@@ -16,6 +16,7 @@ import {
   wasmd,
   wasmdEnabled,
 } from "../testutils.spec";
+import { makeStdTx } from "../tx";
 import { DistributionExtension, setupDistributionExtension } from "./distribution";
 import { LcdClient } from "./lcdclient";
 
@@ -46,15 +47,10 @@ describe("DistributionExtension", () => {
       const memo = "Test delegation for wasmd";
       const { accountNumber, sequence } = await client.getSequence();
       const signDoc = makeSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
-      const { signature } = await wallet.sign(faucet.address, signDoc);
-      const tx = {
-        msg: [msg],
-        fee: defaultFee,
-        memo: memo,
-        signatures: [signature],
-      };
+      const { signed, signature } = await wallet.sign(faucet.address, signDoc);
+      const signedTx = makeStdTx(signed, signature);
 
-      const result = await client.broadcastTx(tx);
+      const result = await client.broadcastTx(signedTx);
       assertIsBroadcastTxSuccess(result);
 
       await sleep(75); // wait until transactions are indexed

--- a/packages/launchpad/src/lcdapi/distribution.spec.ts
+++ b/packages/launchpad/src/lcdapi/distribution.spec.ts
@@ -46,7 +46,7 @@ describe("DistributionExtension", () => {
       const memo = "Test delegation for wasmd";
       const { accountNumber, sequence } = await client.getSequence();
       const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
-      const signature = await wallet.sign(faucet.address, signDoc);
+      const { signature } = await wallet.sign(faucet.address, signDoc);
       const tx = {
         msg: [msg],
         fee: defaultFee,

--- a/packages/launchpad/src/lcdapi/distribution.spec.ts
+++ b/packages/launchpad/src/lcdapi/distribution.spec.ts
@@ -4,7 +4,7 @@ import { sleep } from "@cosmjs/utils";
 
 import { coin, coins } from "../coins";
 import { assertIsBroadcastTxSuccess } from "../cosmosclient";
-import { makeStdSignDoc } from "../encoding";
+import { makeSignDoc } from "../encoding";
 import { MsgDelegate } from "../msgs";
 import { Secp256k1Wallet } from "../secp256k1wallet";
 import { SigningCosmosClient } from "../signingcosmosclient";
@@ -45,7 +45,7 @@ describe("DistributionExtension", () => {
       };
       const memo = "Test delegation for wasmd";
       const { accountNumber, sequence } = await client.getSequence();
-      const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
+      const signDoc = makeSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
       const { signature } = await wallet.sign(faucet.address, signDoc);
       const tx = {
         msg: [msg],

--- a/packages/launchpad/src/lcdapi/distribution.spec.ts
+++ b/packages/launchpad/src/lcdapi/distribution.spec.ts
@@ -4,7 +4,7 @@ import { sleep } from "@cosmjs/utils";
 
 import { coin, coins } from "../coins";
 import { assertIsBroadcastTxSuccess } from "../cosmosclient";
-import { makeSignBytes } from "../encoding";
+import { makeStdSignDoc } from "../encoding";
 import { MsgDelegate } from "../msgs";
 import { Secp256k1Wallet } from "../secp256k1wallet";
 import { SigningCosmosClient } from "../signingcosmosclient";
@@ -45,8 +45,8 @@ describe("DistributionExtension", () => {
       };
       const memo = "Test delegation for wasmd";
       const { accountNumber, sequence } = await client.getSequence();
-      const signBytes = makeSignBytes([msg], defaultFee, chainId, memo, accountNumber, sequence);
-      const signature = await wallet.sign(faucet.address, signBytes);
+      const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
+      const signature = await wallet.sign(faucet.address, signDoc);
       const tx = {
         msg: [msg],
         fee: defaultFee,

--- a/packages/launchpad/src/lcdapi/gov.spec.ts
+++ b/packages/launchpad/src/lcdapi/gov.spec.ts
@@ -58,7 +58,7 @@ describe("GovExtension", () => {
         proposalAccountNumber,
         proposalSequence,
       );
-      const proposalSignature = await wallet.sign(faucet.address, proposalSignDoc);
+      const { signature: proposalSignature } = await wallet.sign(faucet.address, proposalSignDoc);
       const proposalTx = {
         msg: [proposalMsg],
         fee: defaultFee,
@@ -90,7 +90,7 @@ describe("GovExtension", () => {
         voteAccountNumber,
         voteSequence,
       );
-      const voteSignature = await wallet.sign(faucet.address, voteSignDoc);
+      const { signature: voteSignature } = await wallet.sign(faucet.address, voteSignDoc);
       const voteTx = {
         msg: [voteMsg],
         fee: defaultFee,

--- a/packages/launchpad/src/lcdapi/gov.spec.ts
+++ b/packages/launchpad/src/lcdapi/gov.spec.ts
@@ -3,7 +3,7 @@ import { sleep } from "@cosmjs/utils";
 
 import { coins } from "../coins";
 import { assertIsBroadcastTxSuccess } from "../cosmosclient";
-import { makeStdSignDoc } from "../encoding";
+import { makeSignDoc } from "../encoding";
 import { Secp256k1Wallet } from "../secp256k1wallet";
 import { SigningCosmosClient } from "../signingcosmosclient";
 import {
@@ -50,7 +50,7 @@ describe("GovExtension", () => {
       };
       const proposalMemo = "Test proposal for wasmd";
       const { accountNumber: proposalAccountNumber, sequence: proposalSequence } = await client.getSequence();
-      const proposalSignDoc = makeStdSignDoc(
+      const proposalSignDoc = makeSignDoc(
         [proposalMsg],
         defaultFee,
         chainId,
@@ -82,7 +82,7 @@ describe("GovExtension", () => {
       };
       const voteMemo = "Test vote for wasmd";
       const { accountNumber: voteAccountNumber, sequence: voteSequence } = await client.getSequence();
-      const voteSignDoc = makeStdSignDoc(
+      const voteSignDoc = makeSignDoc(
         [voteMsg],
         defaultFee,
         chainId,

--- a/packages/launchpad/src/lcdapi/gov.spec.ts
+++ b/packages/launchpad/src/lcdapi/gov.spec.ts
@@ -3,7 +3,7 @@ import { sleep } from "@cosmjs/utils";
 
 import { coins } from "../coins";
 import { assertIsBroadcastTxSuccess } from "../cosmosclient";
-import { makeSignBytes } from "../encoding";
+import { makeStdSignDoc } from "../encoding";
 import { Secp256k1Wallet } from "../secp256k1wallet";
 import { SigningCosmosClient } from "../signingcosmosclient";
 import {
@@ -50,7 +50,7 @@ describe("GovExtension", () => {
       };
       const proposalMemo = "Test proposal for wasmd";
       const { accountNumber: proposalAccountNumber, sequence: proposalSequence } = await client.getSequence();
-      const proposalSignBytes = makeSignBytes(
+      const proposalSignDoc = makeStdSignDoc(
         [proposalMsg],
         defaultFee,
         chainId,
@@ -58,7 +58,7 @@ describe("GovExtension", () => {
         proposalAccountNumber,
         proposalSequence,
       );
-      const proposalSignature = await wallet.sign(faucet.address, proposalSignBytes);
+      const proposalSignature = await wallet.sign(faucet.address, proposalSignDoc);
       const proposalTx = {
         msg: [proposalMsg],
         fee: defaultFee,
@@ -82,7 +82,7 @@ describe("GovExtension", () => {
       };
       const voteMemo = "Test vote for wasmd";
       const { accountNumber: voteAccountNumber, sequence: voteSequence } = await client.getSequence();
-      const voteSignBytes = makeSignBytes(
+      const voteSignDoc = makeStdSignDoc(
         [voteMsg],
         defaultFee,
         chainId,
@@ -90,7 +90,7 @@ describe("GovExtension", () => {
         voteAccountNumber,
         voteSequence,
       );
-      const voteSignature = await wallet.sign(faucet.address, voteSignBytes);
+      const voteSignature = await wallet.sign(faucet.address, voteSignDoc);
       const voteTx = {
         msg: [voteMsg],
         fee: defaultFee,

--- a/packages/launchpad/src/lcdapi/lcdclient.spec.ts
+++ b/packages/launchpad/src/lcdapi/lcdclient.spec.ts
@@ -20,7 +20,8 @@ import {
   wasmd,
   wasmdEnabled,
 } from "../testutils.spec";
-import { StdFee, StdTx } from "../types";
+import { isWrappedStdTx, StdTx } from "../tx";
+import { StdFee } from "../types";
 import { makeCosmoshubPath } from "../wallet";
 import { setupAuthExtension } from "./auth";
 import { TxsResponse } from "./base";
@@ -493,6 +494,7 @@ describe("LcdClient", () => {
     it("works for cosmoshub example", async () => {
       pendingWithoutWasmd();
       const client = new LcdClient(wasmd.endpoint);
+      assert(isWrappedStdTx(cosmoshub.tx));
       const response = await client.encodeTx(cosmoshub.tx);
       expect(response).toEqual(
         jasmine.objectContaining({

--- a/packages/launchpad/src/lcdapi/lcdclient.spec.ts
+++ b/packages/launchpad/src/lcdapi/lcdclient.spec.ts
@@ -3,7 +3,7 @@ import { assert, sleep } from "@cosmjs/utils";
 
 import { Coin } from "../coins";
 import { isBroadcastTxFailure } from "../cosmosclient";
-import { makeStdSignDoc } from "../encoding";
+import { makeSignDoc } from "../encoding";
 import { parseLogs } from "../logs";
 import { MsgSend } from "../msgs";
 import { Secp256k1Wallet } from "../secp256k1wallet";
@@ -239,7 +239,7 @@ describe("LcdClient", () => {
           };
           const { accountNumber, sequence } = await client.getSequence();
           const chainId = await client.getChainId();
-          const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+          const signDoc = makeSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
           const { signature } = await wallet.sign(walletAddress, signDoc);
           const signedTx: StdTx = {
             msg: [sendMsg],
@@ -537,7 +537,7 @@ describe("LcdClient", () => {
       const client = LcdClient.withExtensions({ apiUrl: wasmd.endpoint }, setupAuthExtension);
       const { account_number, sequence } = (await client.auth.account(faucet.address)).result.value;
 
-      const signDoc = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
+      const signDoc = makeSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
       const { signature } = await wallet.sign(walletAddress, signDoc);
       const signedTx = makeSignedTx(theMsg, fee, memo, signature);
       const result = await client.broadcastTx(signedTx);
@@ -594,9 +594,9 @@ describe("LcdClient", () => {
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
       const { account_number: an3, sequence: sequence3 } = (await client.auth.account(address3)).result.value;
 
-      const signDoc1 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an1, sequence1);
-      const signDoc2 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an2, sequence2);
-      const signDoc3 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an3, sequence3);
+      const signDoc1 = makeSignDoc([theMsg], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeSignDoc([theMsg], fee, wasmd.chainId, memo, an2, sequence2);
+      const signDoc3 = makeSignDoc([theMsg], fee, wasmd.chainId, memo, an3, sequence3);
       const { signature: signature1 } = await account1.sign(address1, signDoc1);
       const { signature: signature2 } = await account2.sign(address2, signDoc2);
       const { signature: signature3 } = await account3.sign(address3, signDoc3);
@@ -658,7 +658,7 @@ describe("LcdClient", () => {
       const client = LcdClient.withExtensions({ apiUrl: wasmd.endpoint }, setupAuthExtension);
       const { account_number, sequence } = (await client.auth.account(walletAddress)).result.value;
 
-      const signDoc = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, account_number, sequence);
+      const signDoc = makeSignDoc([msg1, msg2], fee, wasmd.chainId, memo, account_number, sequence);
       const { signature } = await wallet.sign(walletAddress, signDoc);
       const signedTx: StdTx = {
         msg: [msg1, msg2],
@@ -722,8 +722,8 @@ describe("LcdClient", () => {
       const { account_number: an1, sequence: sequence1 } = (await client.auth.account(address1)).result.value;
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
 
-      const signDoc1 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
-      const signDoc2 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
+      const signDoc1 = makeSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
       const { signature: signature1 } = await account1.sign(address1, signDoc1);
       const { signature: signature2 } = await account2.sign(address2, signDoc2);
       const signedTx: StdTx = {
@@ -793,8 +793,8 @@ describe("LcdClient", () => {
       const { account_number: an1, sequence: sequence1 } = (await client.auth.account(address1)).result.value;
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
 
-      const signDoc1 = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an1, sequence1);
-      const signDoc2 = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an2, sequence2);
+      const signDoc1 = makeSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an2, sequence2);
       const { signature: signature1 } = await account1.sign(address1, signDoc1);
       const { signature: signature2 } = await account2.sign(address2, signDoc2);
       const signedTx: StdTx = {
@@ -859,8 +859,8 @@ describe("LcdClient", () => {
       const { account_number: an1, sequence: sequence1 } = (await client.auth.account(address1)).result.value;
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
 
-      const signDoc1 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
-      const signDoc2 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
+      const signDoc1 = makeSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
       const { signature: signature1 } = await account1.sign(address1, signDoc1);
       const { signature: signature2 } = await account2.sign(address2, signDoc2);
       const signedTx: StdTx = {

--- a/packages/launchpad/src/lcdapi/lcdclient.spec.ts
+++ b/packages/launchpad/src/lcdapi/lcdclient.spec.ts
@@ -3,7 +3,7 @@ import { assert, sleep } from "@cosmjs/utils";
 
 import { Coin } from "../coins";
 import { isBroadcastTxFailure } from "../cosmosclient";
-import { makeSignBytes } from "../encoding";
+import { makeStdSignDoc } from "../encoding";
 import { parseLogs } from "../logs";
 import { MsgSend } from "../msgs";
 import { Secp256k1Wallet } from "../secp256k1wallet";
@@ -239,8 +239,8 @@ describe("LcdClient", () => {
           };
           const { accountNumber, sequence } = await client.getSequence();
           const chainId = await client.getChainId();
-          const signBytes = makeSignBytes([sendMsg], fee, chainId, memo, accountNumber, sequence);
-          const signature = await wallet.sign(walletAddress, signBytes);
+          const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
+          const signature = await wallet.sign(walletAddress, signDoc);
           const signedTx = {
             msg: [sendMsg],
             fee: fee,
@@ -537,8 +537,8 @@ describe("LcdClient", () => {
       const client = LcdClient.withExtensions({ apiUrl: wasmd.endpoint }, setupAuthExtension);
       const { account_number, sequence } = (await client.auth.account(faucet.address)).result.value;
 
-      const signBytes = makeSignBytes([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
-      const signature = await wallet.sign(walletAddress, signBytes);
+      const signDoc = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
+      const signature = await wallet.sign(walletAddress, signDoc);
       const signedTx = makeSignedTx(theMsg, fee, memo, signature);
       const result = await client.broadcastTx(signedTx);
       expect(result.code).toBeUndefined();
@@ -594,12 +594,12 @@ describe("LcdClient", () => {
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
       const { account_number: an3, sequence: sequence3 } = (await client.auth.account(address3)).result.value;
 
-      const signBytes1 = makeSignBytes([theMsg], fee, wasmd.chainId, memo, an1, sequence1);
-      const signBytes2 = makeSignBytes([theMsg], fee, wasmd.chainId, memo, an2, sequence2);
-      const signBytes3 = makeSignBytes([theMsg], fee, wasmd.chainId, memo, an3, sequence3);
-      const signature1 = await account1.sign(address1, signBytes1);
-      const signature2 = await account2.sign(address2, signBytes2);
-      const signature3 = await account3.sign(address3, signBytes3);
+      const signDoc1 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an2, sequence2);
+      const signDoc3 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an3, sequence3);
+      const signature1 = await account1.sign(address1, signDoc1);
+      const signature2 = await account2.sign(address2, signDoc2);
+      const signature3 = await account3.sign(address3, signDoc3);
       const signedTx = {
         msg: [theMsg],
         fee: fee,
@@ -658,13 +658,13 @@ describe("LcdClient", () => {
       const client = LcdClient.withExtensions({ apiUrl: wasmd.endpoint }, setupAuthExtension);
       const { account_number, sequence } = (await client.auth.account(walletAddress)).result.value;
 
-      const signBytes = makeSignBytes([msg1, msg2], fee, wasmd.chainId, memo, account_number, sequence);
-      const signature1 = await wallet.sign(walletAddress, signBytes);
+      const signDoc = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, account_number, sequence);
+      const signature = await wallet.sign(walletAddress, signDoc);
       const signedTx = {
         msg: [msg1, msg2],
         fee: fee,
         memo: memo,
-        signatures: [signature1],
+        signatures: [signature],
       };
       const broadcastResult = await client.broadcastTx(signedTx);
       expect(broadcastResult.code).toBeUndefined();
@@ -722,10 +722,10 @@ describe("LcdClient", () => {
       const { account_number: an1, sequence: sequence1 } = (await client.auth.account(address1)).result.value;
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
 
-      const signBytes1 = makeSignBytes([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
-      const signBytes2 = makeSignBytes([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
-      const signature1 = await account1.sign(address1, signBytes1);
-      const signature2 = await account2.sign(address2, signBytes2);
+      const signDoc1 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
+      const signature1 = await account1.sign(address1, signDoc1);
+      const signature2 = await account2.sign(address2, signDoc2);
       const signedTx = {
         msg: [msg2, msg1],
         fee: fee,
@@ -793,10 +793,10 @@ describe("LcdClient", () => {
       const { account_number: an1, sequence: sequence1 } = (await client.auth.account(address1)).result.value;
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
 
-      const signBytes1 = makeSignBytes([msg1, msg2], fee, wasmd.chainId, memo, an1, sequence1);
-      const signBytes2 = makeSignBytes([msg1, msg2], fee, wasmd.chainId, memo, an2, sequence2);
-      const signature1 = await account1.sign(address1, signBytes1);
-      const signature2 = await account2.sign(address2, signBytes2);
+      const signDoc1 = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an2, sequence2);
+      const signature1 = await account1.sign(address1, signDoc1);
+      const signature2 = await account2.sign(address2, signDoc2);
       const signedTx = {
         msg: [msg1, msg2],
         fee: fee,
@@ -859,10 +859,10 @@ describe("LcdClient", () => {
       const { account_number: an1, sequence: sequence1 } = (await client.auth.account(address1)).result.value;
       const { account_number: an2, sequence: sequence2 } = (await client.auth.account(address2)).result.value;
 
-      const signBytes1 = makeSignBytes([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
-      const signBytes2 = makeSignBytes([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
-      const signature1 = await account1.sign(address1, signBytes1);
-      const signature2 = await account2.sign(address2, signBytes2);
+      const signDoc1 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
+      const signDoc2 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
+      const signature1 = await account1.sign(address1, signDoc1);
+      const signature2 = await account2.sign(address2, signDoc2);
       const signedTx = {
         msg: [msg2, msg1],
         fee: fee,

--- a/packages/launchpad/src/lcdapi/lcdclient.spec.ts
+++ b/packages/launchpad/src/lcdapi/lcdclient.spec.ts
@@ -20,7 +20,7 @@ import {
   wasmd,
   wasmdEnabled,
 } from "../testutils.spec";
-import { StdFee } from "../types";
+import { StdFee, StdTx } from "../types";
 import { makeCosmoshubPath } from "../wallet";
 import { setupAuthExtension } from "./auth";
 import { TxsResponse } from "./base";
@@ -240,8 +240,8 @@ describe("LcdClient", () => {
           const { accountNumber, sequence } = await client.getSequence();
           const chainId = await client.getChainId();
           const signDoc = makeStdSignDoc([sendMsg], fee, chainId, memo, accountNumber, sequence);
-          const signature = await wallet.sign(walletAddress, signDoc);
-          const signedTx = {
+          const { signature } = await wallet.sign(walletAddress, signDoc);
+          const signedTx: StdTx = {
             msg: [sendMsg],
             fee: fee,
             memo: memo,
@@ -538,7 +538,7 @@ describe("LcdClient", () => {
       const { account_number, sequence } = (await client.auth.account(faucet.address)).result.value;
 
       const signDoc = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, account_number, sequence);
-      const signature = await wallet.sign(walletAddress, signDoc);
+      const { signature } = await wallet.sign(walletAddress, signDoc);
       const signedTx = makeSignedTx(theMsg, fee, memo, signature);
       const result = await client.broadcastTx(signedTx);
       expect(result.code).toBeUndefined();
@@ -597,10 +597,10 @@ describe("LcdClient", () => {
       const signDoc1 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an1, sequence1);
       const signDoc2 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an2, sequence2);
       const signDoc3 = makeStdSignDoc([theMsg], fee, wasmd.chainId, memo, an3, sequence3);
-      const signature1 = await account1.sign(address1, signDoc1);
-      const signature2 = await account2.sign(address2, signDoc2);
-      const signature3 = await account3.sign(address3, signDoc3);
-      const signedTx = {
+      const { signature: signature1 } = await account1.sign(address1, signDoc1);
+      const { signature: signature2 } = await account2.sign(address2, signDoc2);
+      const { signature: signature3 } = await account3.sign(address3, signDoc3);
+      const signedTx: StdTx = {
         msg: [theMsg],
         fee: fee,
         memo: memo,
@@ -659,8 +659,8 @@ describe("LcdClient", () => {
       const { account_number, sequence } = (await client.auth.account(walletAddress)).result.value;
 
       const signDoc = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, account_number, sequence);
-      const signature = await wallet.sign(walletAddress, signDoc);
-      const signedTx = {
+      const { signature } = await wallet.sign(walletAddress, signDoc);
+      const signedTx: StdTx = {
         msg: [msg1, msg2],
         fee: fee,
         memo: memo,
@@ -724,9 +724,9 @@ describe("LcdClient", () => {
 
       const signDoc1 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
       const signDoc2 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
-      const signature1 = await account1.sign(address1, signDoc1);
-      const signature2 = await account2.sign(address2, signDoc2);
-      const signedTx = {
+      const { signature: signature1 } = await account1.sign(address1, signDoc1);
+      const { signature: signature2 } = await account2.sign(address2, signDoc2);
+      const signedTx: StdTx = {
         msg: [msg2, msg1],
         fee: fee,
         memo: memo,
@@ -795,9 +795,9 @@ describe("LcdClient", () => {
 
       const signDoc1 = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an1, sequence1);
       const signDoc2 = makeStdSignDoc([msg1, msg2], fee, wasmd.chainId, memo, an2, sequence2);
-      const signature1 = await account1.sign(address1, signDoc1);
-      const signature2 = await account2.sign(address2, signDoc2);
-      const signedTx = {
+      const { signature: signature1 } = await account1.sign(address1, signDoc1);
+      const { signature: signature2 } = await account2.sign(address2, signDoc2);
+      const signedTx: StdTx = {
         msg: [msg1, msg2],
         fee: fee,
         memo: memo,
@@ -861,9 +861,9 @@ describe("LcdClient", () => {
 
       const signDoc1 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an1, sequence1);
       const signDoc2 = makeStdSignDoc([msg2, msg1], fee, wasmd.chainId, memo, an2, sequence2);
-      const signature1 = await account1.sign(address1, signDoc1);
-      const signature2 = await account2.sign(address2, signDoc2);
-      const signedTx = {
+      const { signature: signature1 } = await account1.sign(address1, signDoc1);
+      const { signature: signature2 } = await account2.sign(address2, signDoc2);
+      const signedTx: StdTx = {
         msg: [msg2, msg1],
         fee: fee,
         memo: memo,

--- a/packages/launchpad/src/lcdapi/lcdclient.ts
+++ b/packages/launchpad/src/lcdapi/lcdclient.ts
@@ -2,7 +2,7 @@
 import { assert, isNonNullObject } from "@cosmjs/utils";
 import axios, { AxiosError, AxiosInstance } from "axios";
 
-import { CosmosSdkTx, StdTx } from "../types";
+import { StdTx, WrappedStdTx } from "../tx";
 import {
   BlockResponse,
   BroadcastMode,
@@ -284,7 +284,7 @@ export class LcdClient {
   }
 
   /** returns the amino-encoding of the transaction performed by the server */
-  public async encodeTx(tx: CosmosSdkTx): Promise<EncodeTxResponse> {
+  public async encodeTx(tx: WrappedStdTx): Promise<EncodeTxResponse> {
     const responseData = await this.post("/txs/encode", tx);
     if (!responseData.tx) {
       throw new Error("Unexpected response data format");

--- a/packages/launchpad/src/lcdapi/staking.spec.ts
+++ b/packages/launchpad/src/lcdapi/staking.spec.ts
@@ -16,6 +16,7 @@ import {
   wasmd,
   wasmdEnabled,
 } from "../testutils.spec";
+import { makeStdTx } from "../tx";
 import { LcdClient } from "./lcdclient";
 import { BondStatus, setupStakingExtension, StakingExtension } from "./staking";
 
@@ -47,15 +48,10 @@ describe("StakingExtension", () => {
         const memo = "Test delegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
         const signDoc = makeSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
-        const { signature } = await wallet.sign(faucet.address, signDoc);
-        const tx = {
-          msg: [msg],
-          fee: defaultFee,
-          memo: memo,
-          signatures: [signature],
-        };
+        const { signed, signature } = await wallet.sign(faucet.address, signDoc);
+        const signedTx = makeStdTx(signed, signature);
 
-        const result = await client.broadcastTx(tx);
+        const result = await client.broadcastTx(signedTx);
         assertIsBroadcastTxSuccess(result);
       }
       {
@@ -70,15 +66,10 @@ describe("StakingExtension", () => {
         const memo = "Test undelegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
         const signDoc = makeSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
-        const { signature } = await wallet.sign(faucet.address, signDoc);
-        const tx = {
-          msg: [msg],
-          fee: defaultFee,
-          memo: memo,
-          signatures: [signature],
-        };
+        const { signed, signature } = await wallet.sign(faucet.address, signDoc);
+        const signedTx = makeStdTx(signed, signature);
 
-        const result = await client.broadcastTx(tx);
+        const result = await client.broadcastTx(signedTx);
         assertIsBroadcastTxSuccess(result);
       }
 

--- a/packages/launchpad/src/lcdapi/staking.spec.ts
+++ b/packages/launchpad/src/lcdapi/staking.spec.ts
@@ -3,7 +3,7 @@ import { assert, sleep } from "@cosmjs/utils";
 
 import { coin, coins } from "../coins";
 import { assertIsBroadcastTxSuccess } from "../cosmosclient";
-import { makeStdSignDoc } from "../encoding";
+import { makeSignDoc } from "../encoding";
 import { MsgDelegate, MsgUndelegate } from "../msgs";
 import { Secp256k1Wallet } from "../secp256k1wallet";
 import { SigningCosmosClient } from "../signingcosmosclient";
@@ -46,7 +46,7 @@ describe("StakingExtension", () => {
         };
         const memo = "Test delegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
-        const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
+        const signDoc = makeSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
         const { signature } = await wallet.sign(faucet.address, signDoc);
         const tx = {
           msg: [msg],
@@ -69,7 +69,7 @@ describe("StakingExtension", () => {
         };
         const memo = "Test undelegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
-        const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
+        const signDoc = makeSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
         const { signature } = await wallet.sign(faucet.address, signDoc);
         const tx = {
           msg: [msg],

--- a/packages/launchpad/src/lcdapi/staking.spec.ts
+++ b/packages/launchpad/src/lcdapi/staking.spec.ts
@@ -3,7 +3,7 @@ import { assert, sleep } from "@cosmjs/utils";
 
 import { coin, coins } from "../coins";
 import { assertIsBroadcastTxSuccess } from "../cosmosclient";
-import { makeSignBytes } from "../encoding";
+import { makeStdSignDoc } from "../encoding";
 import { MsgDelegate, MsgUndelegate } from "../msgs";
 import { Secp256k1Wallet } from "../secp256k1wallet";
 import { SigningCosmosClient } from "../signingcosmosclient";
@@ -46,8 +46,8 @@ describe("StakingExtension", () => {
         };
         const memo = "Test delegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
-        const signBytes = makeSignBytes([msg], defaultFee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(faucet.address, signBytes);
+        const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
+        const signature = await wallet.sign(faucet.address, signDoc);
         const tx = {
           msg: [msg],
           fee: defaultFee,
@@ -69,8 +69,8 @@ describe("StakingExtension", () => {
         };
         const memo = "Test undelegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
-        const signBytes = makeSignBytes([msg], defaultFee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(faucet.address, signBytes);
+        const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
+        const signature = await wallet.sign(faucet.address, signDoc);
         const tx = {
           msg: [msg],
           fee: defaultFee,

--- a/packages/launchpad/src/lcdapi/staking.spec.ts
+++ b/packages/launchpad/src/lcdapi/staking.spec.ts
@@ -47,7 +47,7 @@ describe("StakingExtension", () => {
         const memo = "Test delegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
         const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(faucet.address, signDoc);
+        const { signature } = await wallet.sign(faucet.address, signDoc);
         const tx = {
           msg: [msg],
           fee: defaultFee,
@@ -70,7 +70,7 @@ describe("StakingExtension", () => {
         const memo = "Test undelegation for wasmd";
         const { accountNumber, sequence } = await client.getSequence();
         const signDoc = makeStdSignDoc([msg], defaultFee, chainId, memo, accountNumber, sequence);
-        const signature = await wallet.sign(faucet.address, signDoc);
+        const { signature } = await wallet.sign(faucet.address, signDoc);
         const tx = {
           msg: [msg],
           fee: defaultFee,

--- a/packages/launchpad/src/secp256k1wallet.spec.ts
+++ b/packages/launchpad/src/secp256k1wallet.spec.ts
@@ -120,7 +120,7 @@ describe("Secp256k1Wallet", () => {
         account_number: "7",
         sequence: "54",
       };
-      const signature = await wallet.sign(defaultAddress, signDoc);
+      const { signature } = await wallet.sign(defaultAddress, signDoc);
       const valid = await Secp256k1.verifySignature(
         Secp256k1Signature.fromFixedLength(fromBase64(signature.signature)),
         new Sha256(serializeSignDoc(signDoc)).digest(),

--- a/packages/launchpad/src/secp256k1wallet.spec.ts
+++ b/packages/launchpad/src/secp256k1wallet.spec.ts
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Secp256k1, Secp256k1Signature, Sha256 } from "@cosmjs/crypto";
-import { fromBase64, fromHex, toAscii } from "@cosmjs/encoding";
+import { fromBase64, fromHex } from "@cosmjs/encoding";
 
+import { serializeSignDoc, StdSignDoc } from "./encoding";
 import { extractKdfConfiguration, Secp256k1Wallet } from "./secp256k1wallet";
 import { base64Matcher } from "./testutils.spec";
 import { executeKdf, KdfConfiguration } from "./wallet";
@@ -110,11 +112,18 @@ describe("Secp256k1Wallet", () => {
   describe("sign", () => {
     it("resolves to valid signature if enabled", async () => {
       const wallet = await Secp256k1Wallet.fromMnemonic(defaultMnemonic);
-      const message = toAscii("foo bar");
-      const signature = await wallet.sign(defaultAddress, message);
+      const signDoc: StdSignDoc = {
+        msgs: [],
+        fee: { amount: [], gas: "23" },
+        chain_id: "foochain",
+        memo: "hello, world",
+        account_number: "7",
+        sequence: "54",
+      };
+      const signature = await wallet.sign(defaultAddress, signDoc);
       const valid = await Secp256k1.verifySignature(
         Secp256k1Signature.fromFixedLength(fromBase64(signature.signature)),
-        new Sha256(message).digest(),
+        new Sha256(serializeSignDoc(signDoc)).digest(),
         defaultPubkey,
       );
       expect(valid).toEqual(true);

--- a/packages/launchpad/src/secp256k1wallet.spec.ts
+++ b/packages/launchpad/src/secp256k1wallet.spec.ts
@@ -120,10 +120,11 @@ describe("Secp256k1Wallet", () => {
         account_number: "7",
         sequence: "54",
       };
-      const { signature } = await wallet.sign(defaultAddress, signDoc);
+      const { signed, signature } = await wallet.sign(defaultAddress, signDoc);
+      expect(signed).toEqual(signDoc);
       const valid = await Secp256k1.verifySignature(
         Secp256k1Signature.fromFixedLength(fromBase64(signature.signature)),
-        new Sha256(serializeSignDoc(signDoc)).digest(),
+        new Sha256(serializeSignDoc(signed)).digest(),
         defaultPubkey,
       );
       expect(valid).toEqual(true);

--- a/packages/launchpad/src/secp256k1wallet.ts
+++ b/packages/launchpad/src/secp256k1wallet.ts
@@ -263,7 +263,7 @@ export class Secp256k1Wallet implements OfflineSigner {
     const signature = await Secp256k1.createSignature(message, this.privkey);
     const signatureBytes = new Uint8Array([...signature.r(32), ...signature.s(32)]);
     return {
-      signedDoc: signDoc,
+      signed: signDoc,
       signature: encodeSecp256k1Signature(this.pubkey, signatureBytes),
     };
   }

--- a/packages/launchpad/src/secp256k1wallet.ts
+++ b/packages/launchpad/src/secp256k1wallet.ts
@@ -14,18 +14,16 @@ import { assert, isNonNullObject } from "@cosmjs/utils";
 
 import { rawSecp256k1PubkeyToAddress } from "./address";
 import { encodeSecp256k1Signature } from "./signature";
+import { AccountData, OfflineSigner, PrehashType } from "./signer";
 import { StdSignature } from "./types";
 import {
-  AccountData,
   decrypt,
   encrypt,
   EncryptionConfiguration,
   executeKdf,
   KdfConfiguration,
   makeCosmoshubPath,
-  OfflineSigner,
   prehash,
-  PrehashType,
   supportedAlgorithms,
 } from "./wallet";
 

--- a/packages/launchpad/src/secp256k1wallet.ts
+++ b/packages/launchpad/src/secp256k1wallet.ts
@@ -16,8 +16,7 @@ import { assert, isNonNullObject } from "@cosmjs/utils";
 import { rawSecp256k1PubkeyToAddress } from "./address";
 import { serializeSignDoc, StdSignDoc } from "./encoding";
 import { encodeSecp256k1Signature } from "./signature";
-import { AccountData, OfflineSigner } from "./signer";
-import { StdSignature } from "./types";
+import { AccountData, OfflineSigner, SignResponse } from "./signer";
 import {
   decrypt,
   encrypt,
@@ -256,14 +255,17 @@ export class Secp256k1Wallet implements OfflineSigner {
     ];
   }
 
-  public async sign(signerAddress: string, signDoc: StdSignDoc): Promise<StdSignature> {
+  public async sign(signerAddress: string, signDoc: StdSignDoc): Promise<SignResponse> {
     if (signerAddress !== this.address) {
       throw new Error(`Address ${signerAddress} not found in wallet`);
     }
     const message = new Sha256(serializeSignDoc(signDoc)).digest();
     const signature = await Secp256k1.createSignature(message, this.privkey);
     const signatureBytes = new Uint8Array([...signature.r(32), ...signature.s(32)]);
-    return encodeSecp256k1Signature(this.pubkey, signatureBytes);
+    return {
+      signedDoc: signDoc,
+      signature: encodeSecp256k1Signature(this.pubkey, signatureBytes),
+    };
   }
 
   /**

--- a/packages/launchpad/src/sequence.spec.ts
+++ b/packages/launchpad/src/sequence.spec.ts
@@ -1,7 +1,10 @@
+import { assert } from "@cosmjs/utils";
+
 import { findSequenceForSignedTx } from "./sequence";
 import response1 from "./testdata/txresponse1.json";
 import response2 from "./testdata/txresponse2.json";
 import response3 from "./testdata/txresponse3.json";
+import { isWrappedStdTx } from "./tx";
 
 // Those values must match ./testdata/txresponse*.json
 const chainId = "testing";
@@ -10,6 +13,10 @@ const accountNumber = 4;
 describe("sequence", () => {
   describe("findSequenceForSignedTx", () => {
     it("works", async () => {
+      assert(isWrappedStdTx(response1.tx));
+      assert(isWrappedStdTx(response2.tx));
+      assert(isWrappedStdTx(response3.tx));
+
       const current = 100; // what we get from GET /auth/accounts/{address}
       expect(await findSequenceForSignedTx(response1.tx, chainId, accountNumber, current)).toEqual(10);
       // We know response3.height > response1.height, so the sequence must be at least 10+1
@@ -19,6 +26,10 @@ describe("sequence", () => {
     });
 
     it("returns undefined when sequence is not in range", async () => {
+      assert(isWrappedStdTx(response1.tx));
+      assert(isWrappedStdTx(response2.tx));
+      assert(isWrappedStdTx(response3.tx));
+
       expect(await findSequenceForSignedTx(response1.tx, chainId, accountNumber, 5)).toBeUndefined();
       expect(await findSequenceForSignedTx(response1.tx, chainId, accountNumber, 20, 11)).toBeUndefined();
       expect(await findSequenceForSignedTx(response1.tx, chainId, accountNumber, 20, 50)).toBeUndefined();

--- a/packages/launchpad/src/sequence.ts
+++ b/packages/launchpad/src/sequence.ts
@@ -2,7 +2,7 @@ import { Secp256k1, Secp256k1Signature, Sha256 } from "@cosmjs/crypto";
 
 import { makeSignDoc, serializeSignDoc } from "./encoding";
 import { decodeSignature } from "./signature";
-import { CosmosSdkTx } from "./types";
+import { WrappedStdTx } from "./tx";
 
 /**
  * Serach for sequence s with `min` <= `s` < `upperBound` to find the sequence that was used to sign the transaction
@@ -16,7 +16,7 @@ import { CosmosSdkTx } from "./types";
  * @returns the sequence if a match was found and undefined otherwise
  */
 export async function findSequenceForSignedTx(
-  tx: CosmosSdkTx,
+  tx: WrappedStdTx,
   chainId: string,
   accountNumber: number,
   upperBound: number,

--- a/packages/launchpad/src/sequence.ts
+++ b/packages/launchpad/src/sequence.ts
@@ -1,6 +1,6 @@
 import { Secp256k1, Secp256k1Signature, Sha256 } from "@cosmjs/crypto";
 
-import { makeSignBytes } from "./encoding";
+import { makeStdSignDoc, serializeSignDoc } from "./encoding";
 import { decodeSignature } from "./signature";
 import { CosmosSdkTx } from "./types";
 
@@ -30,13 +30,8 @@ export async function findSequenceForSignedTx(
 
   for (let s = min; s < upperBound; s++) {
     // console.log(`Trying sequence ${s}`);
-    const signBytes = makeSignBytes(
-      tx.value.msg,
-      tx.value.fee,
-      chainId,
-      tx.value.memo || "",
-      accountNumber,
-      s,
+    const signBytes = serializeSignDoc(
+      makeStdSignDoc(tx.value.msg, tx.value.fee, chainId, tx.value.memo || "", accountNumber, s),
     );
     const prehashed = new Sha256(signBytes).digest();
     const valid = await Secp256k1.verifySignature(secp256keSignature, prehashed, pubkey);

--- a/packages/launchpad/src/sequence.ts
+++ b/packages/launchpad/src/sequence.ts
@@ -1,6 +1,6 @@
 import { Secp256k1, Secp256k1Signature, Sha256 } from "@cosmjs/crypto";
 
-import { makeStdSignDoc, serializeSignDoc } from "./encoding";
+import { makeSignDoc, serializeSignDoc } from "./encoding";
 import { decodeSignature } from "./signature";
 import { CosmosSdkTx } from "./types";
 
@@ -31,7 +31,7 @@ export async function findSequenceForSignedTx(
   for (let s = min; s < upperBound; s++) {
     // console.log(`Trying sequence ${s}`);
     const signBytes = serializeSignDoc(
-      makeStdSignDoc(tx.value.msg, tx.value.fee, chainId, tx.value.memo || "", accountNumber, s),
+      makeSignDoc(tx.value.msg, tx.value.fee, chainId, tx.value.memo || "", accountNumber, s),
     );
     const prehashed = new Sha256(signBytes).digest();
     const valid = await Secp256k1.verifySignature(secp256keSignature, prehashed, pubkey);

--- a/packages/launchpad/src/signer.ts
+++ b/packages/launchpad/src/signer.ts
@@ -1,3 +1,4 @@
+import { StdSignDoc } from "./encoding";
 import { StdSignature } from "./types";
 
 export type PrehashType = "sha256" | "sha512" | null;
@@ -19,6 +20,13 @@ export interface OfflineSigner {
 
   /**
    * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
+   *
+   * @param signerAddress The address of the account that should sign the transaction
+   * @param signDoc The content that should be signed
    */
-  readonly sign: (address: string, message: Uint8Array, prehashType?: PrehashType) => Promise<StdSignature>;
+  readonly sign: (
+    signerAddress: string,
+    signDoc: StdSignDoc,
+    prehashType?: PrehashType,
+  ) => Promise<StdSignature>;
 }

--- a/packages/launchpad/src/signer.ts
+++ b/packages/launchpad/src/signer.ts
@@ -10,6 +10,15 @@ export interface AccountData {
   readonly pubkey: Uint8Array;
 }
 
+export interface SignResponse {
+  /**
+   * The sign doc that was signed.
+   * This may be different from the input signDoc when the signer modifies it as part of the signing process.
+   */
+  readonly signedDoc: StdSignDoc;
+  readonly signature: StdSignature;
+}
+
 export interface OfflineSigner {
   /**
    * Get AccountData array from wallet. Rejects if not enabled.
@@ -19,8 +28,11 @@ export interface OfflineSigner {
   /**
    * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
    *
+   * The signer implementation may offer the user the ability to override parts of the signDoc. It must
+   * return the doc that was signed in the response.
+   *
    * @param signerAddress The address of the account that should sign the transaction
    * @param signDoc The content that should be signed
    */
-  readonly sign: (signerAddress: string, signDoc: StdSignDoc) => Promise<StdSignature>;
+  readonly sign: (signerAddress: string, signDoc: StdSignDoc) => Promise<SignResponse>;
 }

--- a/packages/launchpad/src/signer.ts
+++ b/packages/launchpad/src/signer.ts
@@ -1,0 +1,24 @@
+import { StdSignature } from "./types";
+
+export type PrehashType = "sha256" | "sha512" | null;
+
+export type Algo = "secp256k1" | "ed25519" | "sr25519";
+
+export interface AccountData {
+  /** A printable address (typically bech32 encoded) */
+  readonly address: string;
+  readonly algo: Algo;
+  readonly pubkey: Uint8Array;
+}
+
+export interface OfflineSigner {
+  /**
+   * Get AccountData array from wallet. Rejects if not enabled.
+   */
+  readonly getAccounts: () => Promise<readonly AccountData[]>;
+
+  /**
+   * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
+   */
+  readonly sign: (address: string, message: Uint8Array, prehashType?: PrehashType) => Promise<StdSignature>;
+}

--- a/packages/launchpad/src/signer.ts
+++ b/packages/launchpad/src/signer.ts
@@ -15,7 +15,7 @@ export interface SignResponse {
    * The sign doc that was signed.
    * This may be different from the input signDoc when the signer modifies it as part of the signing process.
    */
-  readonly signedDoc: StdSignDoc;
+  readonly signed: StdSignDoc;
   readonly signature: StdSignature;
 }
 

--- a/packages/launchpad/src/signer.ts
+++ b/packages/launchpad/src/signer.ts
@@ -1,8 +1,6 @@
 import { StdSignDoc } from "./encoding";
 import { StdSignature } from "./types";
 
-export type PrehashType = "sha256" | "sha512" | null;
-
 export type Algo = "secp256k1" | "ed25519" | "sr25519";
 
 export interface AccountData {
@@ -24,9 +22,5 @@ export interface OfflineSigner {
    * @param signerAddress The address of the account that should sign the transaction
    * @param signDoc The content that should be signed
    */
-  readonly sign: (
-    signerAddress: string,
-    signDoc: StdSignDoc,
-    prehashType?: PrehashType,
-  ) => Promise<StdSignature>;
+  readonly sign: (signerAddress: string, signDoc: StdSignDoc) => Promise<StdSignature>;
 }

--- a/packages/launchpad/src/signingcosmosclient.ts
+++ b/packages/launchpad/src/signingcosmosclient.ts
@@ -89,7 +89,7 @@ export class SigningCosmosClient extends CosmosClient {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
     const signDoc = makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
-    const signature = await this.signer.sign(this.senderAddress, signDoc);
+    const { signature } = await this.signer.sign(this.senderAddress, signDoc);
     const signedTx: StdTx = {
       msg: msgs,
       fee: fee,

--- a/packages/launchpad/src/signingcosmosclient.ts
+++ b/packages/launchpad/src/signingcosmosclient.ts
@@ -5,8 +5,8 @@ import { makeSignBytes } from "./encoding";
 import { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 import { BroadcastMode } from "./lcdapi";
 import { Msg, MsgSend } from "./msgs";
+import { OfflineSigner } from "./signer";
 import { StdFee, StdTx } from "./types";
-import { OfflineSigner } from "./wallet";
 
 /**
  * These fees are used by the higher level methods of SigningCosmosClient

--- a/packages/launchpad/src/signingcosmosclient.ts
+++ b/packages/launchpad/src/signingcosmosclient.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Coin } from "./coins";
 import { Account, BroadcastTxResult, CosmosClient, GetSequenceResult } from "./cosmosclient";
-import { makeSignBytes } from "./encoding";
+import { makeStdSignDoc } from "./encoding";
 import { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 import { BroadcastMode } from "./lcdapi";
 import { Msg, MsgSend } from "./msgs";
@@ -88,8 +88,8 @@ export class SigningCosmosClient extends CosmosClient {
   public async signAndBroadcast(msgs: readonly Msg[], fee: StdFee, memo = ""): Promise<BroadcastTxResult> {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
-    const signBytes = makeSignBytes(msgs, fee, chainId, memo, accountNumber, sequence);
-    const signature = await this.signer.sign(this.senderAddress, signBytes);
+    const signDoc = makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
+    const signature = await this.signer.sign(this.senderAddress, signDoc);
     const signedTx: StdTx = {
       msg: msgs,
       fee: fee,

--- a/packages/launchpad/src/signingcosmosclient.ts
+++ b/packages/launchpad/src/signingcosmosclient.ts
@@ -6,7 +6,8 @@ import { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 import { BroadcastMode } from "./lcdapi";
 import { Msg, MsgSend } from "./msgs";
 import { OfflineSigner } from "./signer";
-import { StdFee, StdTx } from "./types";
+import { StdTx } from "./tx";
+import { StdFee } from "./types";
 
 /**
  * These fees are used by the higher level methods of SigningCosmosClient

--- a/packages/launchpad/src/signingcosmosclient.ts
+++ b/packages/launchpad/src/signingcosmosclient.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Coin } from "./coins";
 import { Account, BroadcastTxResult, CosmosClient, GetSequenceResult } from "./cosmosclient";
-import { makeStdSignDoc } from "./encoding";
+import { makeSignDoc } from "./encoding";
 import { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 import { BroadcastMode } from "./lcdapi";
 import { Msg, MsgSend } from "./msgs";
@@ -88,7 +88,7 @@ export class SigningCosmosClient extends CosmosClient {
   public async signAndBroadcast(msgs: readonly Msg[], fee: StdFee, memo = ""): Promise<BroadcastTxResult> {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
-    const signDoc = makeStdSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
+    const signDoc = makeSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
     const { signature } = await this.signer.sign(this.senderAddress, signDoc);
     const signedTx: StdTx = {
       msg: msgs,

--- a/packages/launchpad/src/signingcosmosclient.ts
+++ b/packages/launchpad/src/signingcosmosclient.ts
@@ -6,7 +6,7 @@ import { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 import { BroadcastMode } from "./lcdapi";
 import { Msg, MsgSend } from "./msgs";
 import { OfflineSigner } from "./signer";
-import { StdTx } from "./tx";
+import { makeStdTx } from "./tx";
 import { StdFee } from "./types";
 
 /**
@@ -90,13 +90,8 @@ export class SigningCosmosClient extends CosmosClient {
     const { accountNumber, sequence } = await this.getSequence();
     const chainId = await this.getChainId();
     const signDoc = makeSignDoc(msgs, fee, chainId, memo, accountNumber, sequence);
-    const { signature } = await this.signer.sign(this.senderAddress, signDoc);
-    const signedTx: StdTx = {
-      msg: msgs,
-      fee: fee,
-      memo: memo,
-      signatures: [signature],
-    };
+    const { signed, signature } = await this.signer.sign(this.senderAddress, signDoc);
+    const signedTx = makeStdTx(signed, signature);
     return this.broadcastTx(signedTx);
   }
 }

--- a/packages/launchpad/src/testutils.spec.ts
+++ b/packages/launchpad/src/testutils.spec.ts
@@ -1,10 +1,6 @@
 import { Random } from "@cosmjs/crypto";
 import { Bech32 } from "@cosmjs/encoding";
 
-import { Msg } from "./msgs";
-import { StdTx } from "./tx";
-import { StdFee, StdSignature } from "./types";
-
 export function makeRandomAddress(): string {
   return Bech32.encode("cosmos", Random.getBytes(20));
 }
@@ -74,13 +70,4 @@ export function pendingWithoutWasmd(): void {
 export function fromOneElementArray<T>(elements: ArrayLike<T>): T {
   if (elements.length !== 1) throw new Error(`Expected exactly one element but got ${elements.length}`);
   return elements[0];
-}
-
-export function makeSignedTx(firstMsg: Msg, fee: StdFee, memo: string, firstSignature: StdSignature): StdTx {
-  return {
-    msg: [firstMsg],
-    fee: fee,
-    memo: memo,
-    signatures: [firstSignature],
-  };
 }

--- a/packages/launchpad/src/testutils.spec.ts
+++ b/packages/launchpad/src/testutils.spec.ts
@@ -2,7 +2,8 @@ import { Random } from "@cosmjs/crypto";
 import { Bech32 } from "@cosmjs/encoding";
 
 import { Msg } from "./msgs";
-import { StdFee, StdSignature, StdTx } from "./types";
+import { StdTx } from "./tx";
+import { StdFee, StdSignature } from "./types";
 
 export function makeRandomAddress(): string {
   return Bech32.encode("cosmos", Random.getBytes(20));

--- a/packages/launchpad/src/tx.spec.ts
+++ b/packages/launchpad/src/tx.spec.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { coins } from "./coins";
+import { makeSignDoc } from "./encoding";
+import { makeStdTx } from "./tx";
+import { StdFee, StdSignature } from "./types";
+
+describe("tx", () => {
+  describe("makeStdTx", () => {
+    it("can make an StdTx from a SignDoc and one signature", () => {
+      const fee: StdFee = { amount: coins(123, "ucosm"), gas: "22" };
+      const signDoc = makeSignDoc([], fee, "chain-xy", "hello", 3, 4);
+      const signature: StdSignature = {
+        pub_key: {
+          type: "tendermint/PubKeySecp256k1",
+          value: "AtQaCqFnshaZQp6rIkvAPyzThvCvXSDO+9AzbxVErqJP",
+        },
+        signature: "1nUcIH0CLT0/nQ0mBTDrT6kMG20NY/PsH7P2gc4bpYNGLEYjBmdWevXUJouSE/9A/60QG9cYeqyTe5kFDeIPxQ==",
+      };
+      const signedTx = makeStdTx(signDoc, signature);
+      expect(signedTx).toEqual({
+        msg: [],
+        memo: "hello",
+        fee: fee,
+        signatures: [signature],
+      });
+    });
+
+    it("can make an StdTx from a SignDoc and multiple signatures", () => {
+      const fee: StdFee = { amount: coins(123, "ucosm"), gas: "22" };
+      const signDoc = makeSignDoc([], fee, "chain-xy", "hello", 3, 4);
+      const signature1: StdSignature = {
+        pub_key: {
+          type: "tendermint/PubKeySecp256k1",
+          value: "AtQaCqFnshaZQp6rIkvAPyzThvCvXSDO+9AzbxVErqJP",
+        },
+        signature: "1nUcIH0CLT0/nQ0mBTDrT6kMG20NY/PsH7P2gc4bpYNGLEYjBmdWevXUJouSE/9A/60QG9cYeqyTe5kFDeIPxQ==",
+      };
+      const signature2: StdSignature = {
+        pub_key: {
+          type: "tendermint/PubKeySecp256k1",
+          value: "A5qFcJBJvEK/fOmEAY0DHNWwSRZ9TEfNZyH8VoVvDtAq",
+        },
+        signature: "NK1Oy4EUGAsoC03c1wi9GG03JC/39LEdautC5Jk643oIbEPqeXHMwaqbdvO/Jws0X/NAXaN8SAy2KNY5Qml+5Q==",
+      };
+      const signedTx = makeStdTx(signDoc, [signature1, signature2]);
+      expect(signedTx).toEqual({
+        msg: [],
+        memo: "hello",
+        fee: fee,
+        signatures: [signature1, signature2],
+      });
+    });
+  });
+});

--- a/packages/launchpad/src/tx.ts
+++ b/packages/launchpad/src/tx.ts
@@ -1,3 +1,4 @@
+import { StdSignDoc } from "./encoding";
 import { Msg } from "./msgs";
 import { StdFee, StdSignature } from "./types";
 
@@ -18,6 +19,18 @@ export function isStdTx(txValue: unknown): txValue is StdTx {
   return (
     typeof memo === "string" && Array.isArray(msg) && typeof fee === "object" && Array.isArray(signatures)
   );
+}
+
+export function makeStdTx(
+  content: Pick<StdSignDoc, "msgs" | "fee" | "memo">,
+  signatures: StdSignature | readonly StdSignature[],
+): StdTx {
+  return {
+    msg: content.msgs,
+    fee: content.fee,
+    memo: content.memo,
+    signatures: Array.isArray(signatures) ? signatures : [signatures],
+  };
 }
 
 /**

--- a/packages/launchpad/src/tx.ts
+++ b/packages/launchpad/src/tx.ts
@@ -1,0 +1,44 @@
+import { Msg } from "./msgs";
+import { StdFee, StdSignature } from "./types";
+
+/**
+ * A Cosmos SDK StdTx
+ *
+ * @see https://docs.cosmos.network/master/modules/auth/03_types.html#stdtx
+ */
+export interface StdTx {
+  readonly msg: readonly Msg[];
+  readonly fee: StdFee;
+  readonly signatures: readonly StdSignature[];
+  readonly memo: string | undefined;
+}
+
+export function isStdTx(txValue: unknown): txValue is StdTx {
+  const { memo, msg, fee, signatures } = txValue as StdTx;
+  return (
+    typeof memo === "string" && Array.isArray(msg) && typeof fee === "object" && Array.isArray(signatures)
+  );
+}
+
+/**
+ * An Amino JSON wrapper around the Tx interface
+ */
+export interface WrappedTx {
+  readonly type: string;
+  readonly value: any;
+}
+
+/**
+ * An Amino JSON wrapper around StdTx
+ */
+export interface WrappedStdTx extends WrappedTx {
+  readonly type: "cosmos-sdk/StdTx";
+  readonly value: StdTx;
+}
+
+export function isWrappedStdTx(wrapped: WrappedTx): wrapped is WrappedStdTx {
+  return (wrapped as WrappedStdTx).type === "cosmos-sdk/StdTx" && isStdTx(wrapped.value);
+}
+
+/** @deprecated use WrappedStdTx */
+export type CosmosSdkTx = WrappedStdTx;

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -1,30 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Coin } from "./coins";
-import { Msg } from "./msgs";
-
-/**
- * A Cosmos SDK StdTx
- *
- * @see https://docs.cosmos.network/master/modules/auth/03_types.html#stdtx
- */
-export interface StdTx {
-  readonly msg: readonly Msg[];
-  readonly fee: StdFee;
-  readonly signatures: readonly StdSignature[];
-  readonly memo: string | undefined;
-}
-
-export function isStdTx(txValue: unknown): txValue is StdTx {
-  const { memo, msg, fee, signatures } = txValue as StdTx;
-  return (
-    typeof memo === "string" && Array.isArray(msg) && typeof fee === "object" && Array.isArray(signatures)
-  );
-}
-
-export interface CosmosSdkTx {
-  readonly type: string;
-  readonly value: StdTx;
-}
 
 export interface StdFee {
   readonly amount: readonly Coin[];

--- a/packages/launchpad/src/wallet.ts
+++ b/packages/launchpad/src/wallet.ts
@@ -3,28 +3,11 @@ import {
   HdPath,
   isArgon2idOptions,
   Random,
-  Sha256,
-  Sha512,
   Slip10RawIndex,
   xchacha20NonceLength,
   Xchacha20poly1305Ietf,
 } from "@cosmjs/crypto";
 import { toAscii } from "@cosmjs/encoding";
-
-import { PrehashType } from "./signer";
-
-export function prehash(bytes: Uint8Array, type: PrehashType): Uint8Array {
-  switch (type) {
-    case null:
-      return new Uint8Array([...bytes]);
-    case "sha256":
-      return new Sha256(bytes).digest();
-    case "sha512":
-      return new Sha512(bytes).digest();
-    default:
-      throw new Error("Unknown prehash type");
-  }
-}
 
 /**
  * The Cosmoshub derivation path in the form `m/44'/118'/0'/0/a`

--- a/packages/launchpad/src/wallet.ts
+++ b/packages/launchpad/src/wallet.ts
@@ -11,30 +11,7 @@ import {
 } from "@cosmjs/crypto";
 import { toAscii } from "@cosmjs/encoding";
 
-import { StdSignature } from "./types";
-
-export type PrehashType = "sha256" | "sha512" | null;
-
-export type Algo = "secp256k1" | "ed25519" | "sr25519";
-
-export interface AccountData {
-  // bech32-encoded
-  readonly address: string;
-  readonly algo: Algo;
-  readonly pubkey: Uint8Array;
-}
-
-export interface OfflineSigner {
-  /**
-   * Get AccountData array from wallet. Rejects if not enabled.
-   */
-  readonly getAccounts: () => Promise<readonly AccountData[]>;
-
-  /**
-   * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
-   */
-  readonly sign: (address: string, message: Uint8Array, prehashType?: PrehashType) => Promise<StdSignature>;
-}
+import { PrehashType } from "./signer";
 
 export function prehash(bytes: Uint8Array, type: PrehashType): Uint8Array {
   switch (type) {

--- a/packages/launchpad/types/cosmosclient.d.ts
+++ b/packages/launchpad/types/cosmosclient.d.ts
@@ -1,7 +1,8 @@
 import { Coin } from "./coins";
 import { AuthExtension, BroadcastMode, LcdClient } from "./lcdapi";
 import { Log } from "./logs";
-import { CosmosSdkTx, PubKey, StdTx } from "./types";
+import { StdTx, WrappedStdTx } from "./tx";
+import { PubKey } from "./types";
 export interface GetSequenceResult {
   readonly accountNumber: number;
   readonly sequence: number;
@@ -78,7 +79,7 @@ export interface IndexedTx {
   readonly code: number;
   readonly rawLog: string;
   readonly logs: readonly Log[];
-  readonly tx: CosmosSdkTx;
+  readonly tx: WrappedStdTx;
   /** The gas limit as set by the user */
   readonly gasWanted?: number;
   /** The gas used by the execution */
@@ -127,7 +128,7 @@ export declare class CosmosClient {
   /**
    * Returns a 32 byte upper-case hex transaction hash (typically used as the transaction ID)
    */
-  getIdentifier(tx: CosmosSdkTx): Promise<string>;
+  getIdentifier(tx: WrappedStdTx): Promise<string>;
   /**
    * Returns account number and sequence.
    *

--- a/packages/launchpad/types/encoding.d.ts
+++ b/packages/launchpad/types/encoding.d.ts
@@ -22,12 +22,3 @@ export declare function makeStdSignDoc(
   sequence: number | string,
 ): StdSignDoc;
 export declare function serializeSignDoc(signDoc: StdSignDoc): Uint8Array;
-/** A convenience helper to create the StdSignDoc and serialize it */
-export declare function makeSignBytes(
-  msgs: readonly Msg[],
-  fee: StdFee,
-  chainId: string,
-  memo: string,
-  accountNumber: number | string,
-  sequence: number | string,
-): Uint8Array;

--- a/packages/launchpad/types/encoding.d.ts
+++ b/packages/launchpad/types/encoding.d.ts
@@ -13,7 +13,7 @@ export interface StdSignDoc {
   readonly msgs: readonly Msg[];
   readonly memo: string;
 }
-export declare function makeStdSignDoc(
+export declare function makeSignDoc(
   msgs: readonly Msg[],
   fee: StdFee,
   chainId: string,

--- a/packages/launchpad/types/encoding.d.ts
+++ b/packages/launchpad/types/encoding.d.ts
@@ -6,13 +6,23 @@ import { StdFee } from "./types";
  * @see https://docs.cosmos.network/master/modules/auth/03_types.html#stdsigndoc
  */
 export interface StdSignDoc {
-  readonly account_number: string;
   readonly chain_id: string;
-  readonly fee: StdFee;
-  readonly memo: string;
-  readonly msgs: readonly Msg[];
+  readonly account_number: string;
   readonly sequence: string;
+  readonly fee: StdFee;
+  readonly msgs: readonly Msg[];
+  readonly memo: string;
 }
+export declare function makeStdSignDoc(
+  msgs: readonly Msg[],
+  fee: StdFee,
+  chainId: string,
+  memo: string,
+  accountNumber: number | string,
+  sequence: number | string,
+): StdSignDoc;
+export declare function serializeSignDoc(signDoc: StdSignDoc): Uint8Array;
+/** A convenience helper to create the StdSignDoc and serialize it */
 export declare function makeSignBytes(
   msgs: readonly Msg[],
   fee: StdFee,

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -96,15 +96,8 @@ export {
 } from "./pubkey";
 export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
+export { AccountData, Algo, PrehashType, OfflineSigner } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
 export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
-export {
-  AccountData,
-  Algo,
-  PrehashType,
-  OfflineSigner,
-  makeCosmoshubPath,
-  executeKdf,
-  KdfConfiguration,
-} from "./wallet";
+export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";
 export { extractKdfConfiguration, Secp256k1Wallet } from "./secp256k1wallet";

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -26,7 +26,7 @@ export {
   isSearchBySentFromOrToQuery,
   isSearchByTagsQuery,
 } from "./cosmosclient";
-export { makeSignBytes, StdSignDoc } from "./encoding";
+export { makeSignBytes, makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
 export { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 export {
   AuthAccountsResponse,

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -98,7 +98,7 @@ export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
 export { AccountData, Algo, OfflineSigner, SignResponse } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
-export { isStdTx, isWrappedStdTx, CosmosSdkTx, StdTx, WrappedStdTx, WrappedTx } from "./tx";
+export { isStdTx, isWrappedStdTx, makeStdTx, CosmosSdkTx, StdTx, WrappedStdTx, WrappedTx } from "./tx";
 export { pubkeyType, PubKey, StdFee, StdSignature } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";
 export { extractKdfConfiguration, Secp256k1Wallet } from "./secp256k1wallet";

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -26,7 +26,7 @@ export {
   isSearchBySentFromOrToQuery,
   isSearchByTagsQuery,
 } from "./cosmosclient";
-export { makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
+export { makeSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
 export { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 export {
   AuthAccountsResponse,

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -26,7 +26,7 @@ export {
   isSearchBySentFromOrToQuery,
   isSearchByTagsQuery,
 } from "./cosmosclient";
-export { makeSignBytes, makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
+export { makeStdSignDoc, serializeSignDoc, StdSignDoc } from "./encoding";
 export { buildFeeTable, FeeTable, GasLimits, GasPrice } from "./gas";
 export {
   AuthAccountsResponse,

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -96,7 +96,7 @@ export {
 } from "./pubkey";
 export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
-export { AccountData, Algo, PrehashType, OfflineSigner } from "./signer";
+export { AccountData, Algo, OfflineSigner } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
 export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -98,6 +98,7 @@ export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
 export { AccountData, Algo, OfflineSigner, SignResponse } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
-export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
+export { isStdTx, isWrappedStdTx, CosmosSdkTx, StdTx, WrappedStdTx, WrappedTx } from "./tx";
+export { pubkeyType, PubKey, StdFee, StdSignature } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";
 export { extractKdfConfiguration, Secp256k1Wallet } from "./secp256k1wallet";

--- a/packages/launchpad/types/index.d.ts
+++ b/packages/launchpad/types/index.d.ts
@@ -96,7 +96,7 @@ export {
 } from "./pubkey";
 export { findSequenceForSignedTx } from "./sequence";
 export { encodeSecp256k1Signature, decodeSignature } from "./signature";
-export { AccountData, Algo, OfflineSigner } from "./signer";
+export { AccountData, Algo, OfflineSigner, SignResponse } from "./signer";
 export { CosmosFeeTable, SigningCosmosClient } from "./signingcosmosclient";
 export { isStdTx, pubkeyType, CosmosSdkTx, PubKey, StdFee, StdSignature, StdTx } from "./types";
 export { makeCosmoshubPath, executeKdf, KdfConfiguration } from "./wallet";

--- a/packages/launchpad/types/lcdapi/base.d.ts
+++ b/packages/launchpad/types/lcdapi/base.d.ts
@@ -1,4 +1,4 @@
-import { CosmosSdkTx } from "../types";
+import { WrappedStdTx } from "../tx";
 /**
  * The mode used to send transaction
  *
@@ -93,7 +93,7 @@ export interface TxsResponse {
   readonly code?: number;
   readonly raw_log: string;
   readonly logs?: unknown[];
-  readonly tx: CosmosSdkTx;
+  readonly tx: WrappedStdTx;
   /** The gas limit as set by the user */
   readonly gas_wanted?: string;
   /** The gas used by the execution */

--- a/packages/launchpad/types/lcdapi/lcdclient.d.ts
+++ b/packages/launchpad/types/lcdapi/lcdclient.d.ts
@@ -1,4 +1,4 @@
-import { CosmosSdkTx, StdTx } from "../types";
+import { StdTx, WrappedStdTx } from "../tx";
 import {
   BlockResponse,
   BroadcastMode,
@@ -151,7 +151,7 @@ export declare class LcdClient {
   txById(id: string): Promise<TxsResponse>;
   txsQuery(query: string): Promise<SearchTxsResponse>;
   /** returns the amino-encoding of the transaction performed by the server */
-  encodeTx(tx: CosmosSdkTx): Promise<EncodeTxResponse>;
+  encodeTx(tx: WrappedStdTx): Promise<EncodeTxResponse>;
   /**
    * Broadcasts a signed transaction to the transaction pool.
    * Depending on the client's broadcast mode, this might or might

--- a/packages/launchpad/types/secp256k1wallet.d.ts
+++ b/packages/launchpad/types/secp256k1wallet.d.ts
@@ -1,7 +1,6 @@
 import { HdPath } from "@cosmjs/crypto";
 import { StdSignDoc } from "./encoding";
-import { AccountData, OfflineSigner } from "./signer";
-import { StdSignature } from "./types";
+import { AccountData, OfflineSigner, SignResponse } from "./signer";
 import { EncryptionConfiguration, KdfConfiguration } from "./wallet";
 /**
  * This interface describes a JSON object holding the encrypted wallet and the meta data.
@@ -87,7 +86,7 @@ export declare class Secp256k1Wallet implements OfflineSigner {
   get mnemonic(): string;
   private get address();
   getAccounts(): Promise<readonly AccountData[]>;
-  sign(signerAddress: string, signDoc: StdSignDoc): Promise<StdSignature>;
+  sign(signerAddress: string, signDoc: StdSignDoc): Promise<SignResponse>;
   /**
    * Generates an encrypted serialization of this wallet.
    *

--- a/packages/launchpad/types/secp256k1wallet.d.ts
+++ b/packages/launchpad/types/secp256k1wallet.d.ts
@@ -1,6 +1,7 @@
 import { HdPath } from "@cosmjs/crypto";
+import { AccountData, OfflineSigner, PrehashType } from "./signer";
 import { StdSignature } from "./types";
-import { AccountData, EncryptionConfiguration, KdfConfiguration, OfflineSigner, PrehashType } from "./wallet";
+import { EncryptionConfiguration, KdfConfiguration } from "./wallet";
 /**
  * This interface describes a JSON object holding the encrypted wallet and the meta data.
  * All fields in here must be JSON types.

--- a/packages/launchpad/types/secp256k1wallet.d.ts
+++ b/packages/launchpad/types/secp256k1wallet.d.ts
@@ -1,5 +1,6 @@
 import { HdPath } from "@cosmjs/crypto";
-import { AccountData, OfflineSigner, PrehashType } from "./signer";
+import { StdSignDoc } from "./encoding";
+import { AccountData, OfflineSigner } from "./signer";
 import { StdSignature } from "./types";
 import { EncryptionConfiguration, KdfConfiguration } from "./wallet";
 /**
@@ -86,7 +87,7 @@ export declare class Secp256k1Wallet implements OfflineSigner {
   get mnemonic(): string;
   private get address();
   getAccounts(): Promise<readonly AccountData[]>;
-  sign(address: string, message: Uint8Array, prehashType?: PrehashType): Promise<StdSignature>;
+  sign(signerAddress: string, signDoc: StdSignDoc): Promise<StdSignature>;
   /**
    * Generates an encrypted serialization of this wallet.
    *

--- a/packages/launchpad/types/sequence.d.ts
+++ b/packages/launchpad/types/sequence.d.ts
@@ -1,4 +1,4 @@
-import { CosmosSdkTx } from "./types";
+import { WrappedStdTx } from "./tx";
 /**
  * Serach for sequence s with `min` <= `s` < `upperBound` to find the sequence that was used to sign the transaction
  *
@@ -11,7 +11,7 @@ import { CosmosSdkTx } from "./types";
  * @returns the sequence if a match was found and undefined otherwise
  */
 export declare function findSequenceForSignedTx(
-  tx: CosmosSdkTx,
+  tx: WrappedStdTx,
   chainId: string,
   accountNumber: number,
   upperBound: number,

--- a/packages/launchpad/types/signer.d.ts
+++ b/packages/launchpad/types/signer.d.ts
@@ -7,6 +7,14 @@ export interface AccountData {
   readonly algo: Algo;
   readonly pubkey: Uint8Array;
 }
+export interface SignResponse {
+  /**
+   * The sign doc that was signed.
+   * This may be different from the input signDoc when the signer modifies it as part of the signing process.
+   */
+  readonly signedDoc: StdSignDoc;
+  readonly signature: StdSignature;
+}
 export interface OfflineSigner {
   /**
    * Get AccountData array from wallet. Rejects if not enabled.
@@ -15,8 +23,11 @@ export interface OfflineSigner {
   /**
    * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
    *
+   * The signer implementation may offer the user the ability to override parts of the signDoc. It must
+   * return the doc that was signed in the response.
+   *
    * @param signerAddress The address of the account that should sign the transaction
    * @param signDoc The content that should be signed
    */
-  readonly sign: (signerAddress: string, signDoc: StdSignDoc) => Promise<StdSignature>;
+  readonly sign: (signerAddress: string, signDoc: StdSignDoc) => Promise<SignResponse>;
 }

--- a/packages/launchpad/types/signer.d.ts
+++ b/packages/launchpad/types/signer.d.ts
@@ -1,3 +1,4 @@
+import { StdSignDoc } from "./encoding";
 import { StdSignature } from "./types";
 export declare type PrehashType = "sha256" | "sha512" | null;
 export declare type Algo = "secp256k1" | "ed25519" | "sr25519";
@@ -14,6 +15,13 @@ export interface OfflineSigner {
   readonly getAccounts: () => Promise<readonly AccountData[]>;
   /**
    * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
+   *
+   * @param signerAddress The address of the account that should sign the transaction
+   * @param signDoc The content that should be signed
    */
-  readonly sign: (address: string, message: Uint8Array, prehashType?: PrehashType) => Promise<StdSignature>;
+  readonly sign: (
+    signerAddress: string,
+    signDoc: StdSignDoc,
+    prehashType?: PrehashType,
+  ) => Promise<StdSignature>;
 }

--- a/packages/launchpad/types/signer.d.ts
+++ b/packages/launchpad/types/signer.d.ts
@@ -1,6 +1,5 @@
 import { StdSignDoc } from "./encoding";
 import { StdSignature } from "./types";
-export declare type PrehashType = "sha256" | "sha512" | null;
 export declare type Algo = "secp256k1" | "ed25519" | "sr25519";
 export interface AccountData {
   /** A printable address (typically bech32 encoded) */
@@ -19,9 +18,5 @@ export interface OfflineSigner {
    * @param signerAddress The address of the account that should sign the transaction
    * @param signDoc The content that should be signed
    */
-  readonly sign: (
-    signerAddress: string,
-    signDoc: StdSignDoc,
-    prehashType?: PrehashType,
-  ) => Promise<StdSignature>;
+  readonly sign: (signerAddress: string, signDoc: StdSignDoc) => Promise<StdSignature>;
 }

--- a/packages/launchpad/types/signer.d.ts
+++ b/packages/launchpad/types/signer.d.ts
@@ -1,0 +1,19 @@
+import { StdSignature } from "./types";
+export declare type PrehashType = "sha256" | "sha512" | null;
+export declare type Algo = "secp256k1" | "ed25519" | "sr25519";
+export interface AccountData {
+  /** A printable address (typically bech32 encoded) */
+  readonly address: string;
+  readonly algo: Algo;
+  readonly pubkey: Uint8Array;
+}
+export interface OfflineSigner {
+  /**
+   * Get AccountData array from wallet. Rejects if not enabled.
+   */
+  readonly getAccounts: () => Promise<readonly AccountData[]>;
+  /**
+   * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
+   */
+  readonly sign: (address: string, message: Uint8Array, prehashType?: PrehashType) => Promise<StdSignature>;
+}

--- a/packages/launchpad/types/signer.d.ts
+++ b/packages/launchpad/types/signer.d.ts
@@ -12,7 +12,7 @@ export interface SignResponse {
    * The sign doc that was signed.
    * This may be different from the input signDoc when the signer modifies it as part of the signing process.
    */
-  readonly signedDoc: StdSignDoc;
+  readonly signed: StdSignDoc;
   readonly signature: StdSignature;
 }
 export interface OfflineSigner {

--- a/packages/launchpad/types/signingcosmosclient.d.ts
+++ b/packages/launchpad/types/signingcosmosclient.d.ts
@@ -3,8 +3,8 @@ import { Account, BroadcastTxResult, CosmosClient, GetSequenceResult } from "./c
 import { FeeTable, GasLimits, GasPrice } from "./gas";
 import { BroadcastMode } from "./lcdapi";
 import { Msg } from "./msgs";
+import { OfflineSigner } from "./signer";
 import { StdFee } from "./types";
-import { OfflineSigner } from "./wallet";
 /**
  * These fees are used by the higher level methods of SigningCosmosClient
  */

--- a/packages/launchpad/types/tx.d.ts
+++ b/packages/launchpad/types/tx.d.ts
@@ -1,3 +1,4 @@
+import { StdSignDoc } from "./encoding";
 import { Msg } from "./msgs";
 import { StdFee, StdSignature } from "./types";
 /**
@@ -12,6 +13,10 @@ export interface StdTx {
   readonly memo: string | undefined;
 }
 export declare function isStdTx(txValue: unknown): txValue is StdTx;
+export declare function makeStdTx(
+  content: Pick<StdSignDoc, "msgs" | "fee" | "memo">,
+  signatures: StdSignature | readonly StdSignature[],
+): StdTx;
 /**
  * An Amino JSON wrapper around the Tx interface
  */

--- a/packages/launchpad/types/tx.d.ts
+++ b/packages/launchpad/types/tx.d.ts
@@ -1,0 +1,31 @@
+import { Msg } from "./msgs";
+import { StdFee, StdSignature } from "./types";
+/**
+ * A Cosmos SDK StdTx
+ *
+ * @see https://docs.cosmos.network/master/modules/auth/03_types.html#stdtx
+ */
+export interface StdTx {
+  readonly msg: readonly Msg[];
+  readonly fee: StdFee;
+  readonly signatures: readonly StdSignature[];
+  readonly memo: string | undefined;
+}
+export declare function isStdTx(txValue: unknown): txValue is StdTx;
+/**
+ * An Amino JSON wrapper around the Tx interface
+ */
+export interface WrappedTx {
+  readonly type: string;
+  readonly value: any;
+}
+/**
+ * An Amino JSON wrapper around StdTx
+ */
+export interface WrappedStdTx extends WrappedTx {
+  readonly type: "cosmos-sdk/StdTx";
+  readonly value: StdTx;
+}
+export declare function isWrappedStdTx(wrapped: WrappedTx): wrapped is WrappedStdTx;
+/** @deprecated use WrappedStdTx */
+export declare type CosmosSdkTx = WrappedStdTx;

--- a/packages/launchpad/types/types.d.ts
+++ b/packages/launchpad/types/types.d.ts
@@ -1,21 +1,4 @@
 import { Coin } from "./coins";
-import { Msg } from "./msgs";
-/**
- * A Cosmos SDK StdTx
- *
- * @see https://docs.cosmos.network/master/modules/auth/03_types.html#stdtx
- */
-export interface StdTx {
-  readonly msg: readonly Msg[];
-  readonly fee: StdFee;
-  readonly signatures: readonly StdSignature[];
-  readonly memo: string | undefined;
-}
-export declare function isStdTx(txValue: unknown): txValue is StdTx;
-export interface CosmosSdkTx {
-  readonly type: string;
-  readonly value: StdTx;
-}
 export interface StdFee {
   readonly amount: readonly Coin[];
   readonly gas: string;

--- a/packages/launchpad/types/wallet.d.ts
+++ b/packages/launchpad/types/wallet.d.ts
@@ -1,6 +1,4 @@
 import { HdPath } from "@cosmjs/crypto";
-import { PrehashType } from "./signer";
-export declare function prehash(bytes: Uint8Array, type: PrehashType): Uint8Array;
 /**
  * The Cosmoshub derivation path in the form `m/44'/118'/0'/0/a`
  * with 0-based account index `a`.

--- a/packages/launchpad/types/wallet.d.ts
+++ b/packages/launchpad/types/wallet.d.ts
@@ -1,22 +1,5 @@
 import { HdPath } from "@cosmjs/crypto";
-import { StdSignature } from "./types";
-export declare type PrehashType = "sha256" | "sha512" | null;
-export declare type Algo = "secp256k1" | "ed25519" | "sr25519";
-export interface AccountData {
-  readonly address: string;
-  readonly algo: Algo;
-  readonly pubkey: Uint8Array;
-}
-export interface OfflineSigner {
-  /**
-   * Get AccountData array from wallet. Rejects if not enabled.
-   */
-  readonly getAccounts: () => Promise<readonly AccountData[]>;
-  /**
-   * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
-   */
-  readonly sign: (address: string, message: Uint8Array, prehashType?: PrehashType) => Promise<StdSignature>;
-}
+import { PrehashType } from "./signer";
 export declare function prehash(bytes: Uint8Array, type: PrehashType): Uint8Array;
 /**
  * The Cosmoshub derivation path in the form `m/44'/118'/0'/0/a`


### PR DESCRIPTION
This feature was requested by Keplr to allow the user to adjust things like gas price. This basically implements https://github.com/CosmWasm/cosmjs/pull/403#issuecomment-683477227. See `signer.ts` for the updated interface.

The reason why I chose to return `{ signedDoc: StdSignDoc, signature: StdSignature }` instead of `StdTx` is that it works better when collecting multiple signatures from multiple sign operations. In this case the `StdTx` returned from one signer is not really something you can submit as a signed transaction. Also returning `StdTx` does not allow the caller to detect changes in `account_number` and `sequence`.

~Based on #433~

- [x] Base implementation
- [x] Pull out Ledger demo commits
- [x] Create a helper that combines an StdSignDoc and a single StdSignature into a signed transaction