### PR TITLE
Enable explicit-member-accessibility and no-parameter-properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     "@typescript-eslint/await-thenable": "warn",
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/explicit-function-return-type": ["warn", { allowExpressions: true }],
+    "@typescript-eslint/explicit-member-accessibility": "warn",
     "@typescript-eslint/naming-convention": [
       "warn",
       {
@@ -65,6 +66,7 @@ module.exports = {
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-floating-promises": "warn",
+    "@typescript-eslint/no-parameter-properties": "warn",
     "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     "@typescript-eslint/no-unnecessary-type-assertion": "warn",
     "@typescript-eslint/no-use-before-define": "warn",
@@ -76,6 +78,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/explicit-member-accessibility": "off",
       },
     },
     {

--- a/packages/faucet/src/api/httperror.ts
+++ b/packages/faucet/src/api/httperror.ts
@@ -1,5 +1,10 @@
 export class HttpError extends Error {
-  constructor(public readonly status: number, text: string, public readonly expose: boolean = true) {
+  public readonly status: number;
+  public readonly expose: boolean;
+
+  public constructor(status: number, text: string, expose = true) {
     super(text);
+    this.status = status;
+    this.expose = expose;
   }
 }

--- a/packages/faucet/src/api/webserver.ts
+++ b/packages/faucet/src/api/webserver.ts
@@ -17,7 +17,7 @@ export interface ChainConstants {
 export class Webserver {
   private readonly api = new Koa();
 
-  constructor(faucet: Faucet, chainConstants: ChainConstants) {
+  public constructor(faucet: Faucet, chainConstants: ChainConstants) {
     this.api.use(cors());
     this.api.use(bodyParser());
 

--- a/packages/launchpad-ledger/src/launchpadledger.ts
+++ b/packages/launchpad-ledger/src/launchpadledger.ts
@@ -57,7 +57,7 @@ export class LaunchpadLedger {
   public readonly platform: string;
   public readonly userAgent: string | null;
 
-  constructor(options: LaunchpadLedgerOptions = {}) {
+  public constructor(options: LaunchpadLedgerOptions = {}) {
     const defaultOptions = {
       hdPaths: [cosmosHdPath],
       prefix: cosmosBech32Prefix,
@@ -81,7 +81,7 @@ export class LaunchpadLedger {
     }
   }
 
-  async connect(timeout = defaultInteractionTimeout): Promise<LaunchpadLedger> {
+  public async connect(timeout = defaultInteractionTimeout): Promise<LaunchpadLedger> {
     // assume good connection if connected once
     if (this.cosmosApp) {
       return this;
@@ -98,7 +98,7 @@ export class LaunchpadLedger {
     return this;
   }
 
-  async getCosmosAppVersion(): Promise<string> {
+  public async getCosmosAppVersion(): Promise<string> {
     await this.connect();
     assert(this.cosmosApp, "Cosmos Ledger App is not connected");
 
@@ -110,7 +110,7 @@ export class LaunchpadLedger {
     return `${major}.${minor}.${patch}`;
   }
 
-  async getPubkey(hdPath?: HdPath): Promise<Uint8Array> {
+  public async getPubkey(hdPath?: HdPath): Promise<Uint8Array> {
     await this.connect();
     assert(this.cosmosApp, "Cosmos Ledger App is not connected");
 
@@ -121,7 +121,7 @@ export class LaunchpadLedger {
     return Uint8Array.from((response as PublicKeyResponse).compressed_pk);
   }
 
-  async getPubkeys(): Promise<readonly Uint8Array[]> {
+  public async getPubkeys(): Promise<readonly Uint8Array[]> {
     return this.hdPaths.reduce(
       (promise: Promise<readonly Uint8Array[]>, hdPath) =>
         promise.then(async (pubkeys) => [...pubkeys, await this.getPubkey(hdPath)]),
@@ -129,12 +129,12 @@ export class LaunchpadLedger {
     );
   }
 
-  async getCosmosAddress(pubkey?: Uint8Array): Promise<string> {
+  public async getCosmosAddress(pubkey?: Uint8Array): Promise<string> {
     const pubkeyToUse = pubkey || (await this.getPubkey());
     return CosmosApp.getBech32FromPK(this.prefix, Buffer.from(pubkeyToUse));
   }
 
-  async sign(message: Uint8Array, hdPath?: HdPath): Promise<Uint8Array> {
+  public async sign(message: Uint8Array, hdPath?: HdPath): Promise<Uint8Array> {
     await this.connect();
     assert(this.cosmosApp, "Cosmos Ledger App is not connected");
 

--- a/packages/launchpad-ledger/src/ledgersigner.ts
+++ b/packages/launchpad-ledger/src/ledgersigner.ts
@@ -15,7 +15,7 @@ export class LedgerSigner implements OfflineSigner {
   private readonly hdPaths: readonly HdPath[];
   private accounts?: readonly AccountData[];
 
-  constructor(options: LaunchpadLedgerOptions = {}) {
+  public constructor(options: LaunchpadLedgerOptions = {}) {
     this.hdPaths = options.hdPaths || [makeCosmoshubPath(0)];
     this.ledger = new LaunchpadLedger(options);
   }

--- a/packages/launchpad/src/gas.ts
+++ b/packages/launchpad/src/gas.ts
@@ -9,7 +9,7 @@ export class GasPrice {
   public readonly amount: Decimal;
   public readonly denom: string;
 
-  constructor(amount: Decimal, denom: string) {
+  public constructor(amount: Decimal, denom: string) {
     this.amount = amount;
     this.denom = denom;
   }

--- a/packages/proto-signing/src/registry.ts
+++ b/packages/proto-signing/src/registry.ts
@@ -38,7 +38,7 @@ const defaultTypeUrls = {
 export class Registry {
   private readonly types: Map<string, GeneratedType>;
 
-  constructor(customTypes: Iterable<[string, GeneratedType]> = []) {
+  public constructor(customTypes: Iterable<[string, GeneratedType]> = []) {
     const { cosmosCoin, cosmosMsgSend } = defaultTypeUrls;
     this.types = new Map<string, GeneratedType>([
       [cosmosCoin, cosmos.Coin],


### PR DESCRIPTION
Two linter rules we used to have in the IOV Core days